### PR TITLE
Add Hangfire server with plugin command handler architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+**/bin/
+**/obj/
+plugins/**/*.dll
+plugins/**/*.pdb

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # TaskHub
+
+Sample Hangfire-based server with plugin-based command handlers and service plugins.
+
+## Building
+
+Requires the .NET 8 SDK.
+
+```
+dotnet build
+```
+
+## Running
+
+Build the solution and run the server:
+
+```
+dotnet run --project src/TaskHub.Server
+```
+
+The server exposes a minimal API:
+
+- `POST /commands/{handler}?arg=value` – enqueue a command handled by a plugin.
+- `POST /commands/{id}/cancel` – cancel a queued job.
+- `GET /dlls` – list loaded plugin assemblies.
+
+Plugins must be compiled and copied under the `plugins` directory as described in the project.

--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.Abstractions", "src/TaskHub.Abstractions/TaskHub.Abstractions.csproj", "{66A1BBE9-8CEA-4EF6-A168-94DF8EA8CFDF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.Server", "src/TaskHub.Server/TaskHub.Server.csproj", "{20BE2950-701D-4DFF-97A7-8DA41CB75EFE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EchoHandler", "plugins/handlers/EchoHandler/EchoHandler.csproj", "{AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpServicePlugin", "plugins/services/HttpServicePlugin/HttpServicePlugin.csproj", "{DB07147A-1AC2-4E01-9C32-82300A5243EB}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {66A1BBE9-8CEA-4EF6-A168-94DF8EA8CFDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {66A1BBE9-8CEA-4EF6-A168-94DF8EA8CFDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {66A1BBE9-8CEA-4EF6-A168-94DF8EA8CFDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {66A1BBE9-8CEA-4EF6-A168-94DF8EA8CFDF}.Release|Any CPU.Build.0 = Release|Any CPU
+        {20BE2950-701D-4DFF-97A7-8DA41CB75EFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {20BE2950-701D-4DFF-97A7-8DA41CB75EFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {20BE2950-701D-4DFF-97A7-8DA41CB75EFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {20BE2950-701D-4DFF-97A7-8DA41CB75EFE}.Release|Any CPU.Build.0 = Release|Any CPU
+        {AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}.Release|Any CPU.Build.0 = Release|Any CPU
+        {DB07147A-1AC2-4E01-9C32-82300A5243EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {DB07147A-1AC2-4E01-9C32-82300A5243EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {DB07147A-1AC2-4E01-9C32-82300A5243EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {DB07147A-1AC2-4E01-9C32-82300A5243EB}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/plugins/handlers/EchoHandler/EchoCommandHandler.cs
+++ b/plugins/handlers/EchoHandler/EchoCommandHandler.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace EchoHandler;
+
+public class EchoCommandHandler : ICommandHandler
+{
+    public string Name => "echo";
+
+    public async Task ExecuteAsync(string arguments, IServicePlugin service, CancellationToken cancellationToken)
+    {
+        var result = await service.GetAsync(arguments, cancellationToken);
+        Console.WriteLine($"Echo: {result}");
+    }
+}

--- a/plugins/handlers/EchoHandler/EchoHandler.csproj
+++ b/plugins/handlers/EchoHandler/EchoHandler.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/plugins/services/HttpServicePlugin/HttpService.cs
+++ b/plugins/services/HttpServicePlugin/HttpService.cs
@@ -1,0 +1,17 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace HttpServicePlugin;
+
+public class HttpServicePlugin : IServicePlugin
+{
+    public string Name => "http";
+
+    public async Task<string> GetAsync(string resource, CancellationToken cancellationToken)
+    {
+        using var client = new HttpClient();
+        return await client.GetStringAsync(resource, cancellationToken);
+    }
+}

--- a/plugins/services/HttpServicePlugin/HttpServicePlugin.csproj
+++ b/plugins/services/HttpServicePlugin/HttpServicePlugin.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/src/TaskHub.Abstractions/Interfaces/ICommandHandler.cs
+++ b/src/TaskHub.Abstractions/Interfaces/ICommandHandler.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TaskHub.Abstractions;
+
+public interface ICommandHandler
+{
+    string Name { get; }
+    Task ExecuteAsync(string arguments, IServicePlugin service, CancellationToken cancellationToken);
+}

--- a/src/TaskHub.Abstractions/Interfaces/IServicePlugin.cs
+++ b/src/TaskHub.Abstractions/Interfaces/IServicePlugin.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TaskHub.Abstractions;
+
+public interface IServicePlugin
+{
+    string Name { get; }
+    Task<string> GetAsync(string resource, CancellationToken cancellationToken);
+}

--- a/src/TaskHub.Abstractions/TaskHub.Abstractions.csproj
+++ b/src/TaskHub.Abstractions/TaskHub.Abstractions.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/src/TaskHub.Server/CommandExecutor.cs
+++ b/src/TaskHub.Server/CommandExecutor.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace TaskHub.Server;
+
+public class CommandExecutor
+{
+    private readonly PluginManager _manager;
+
+    public CommandExecutor(PluginManager manager)
+    {
+        _manager = manager;
+    }
+
+    public async Task Execute(string handlerName, string arguments, CancellationToken token)
+    {
+        var handler = _manager.GetHandler(handlerName);
+        if (handler == null)
+        {
+            throw new InvalidOperationException($"Handler {handlerName} not found.");
+        }
+
+        await handler.ExecuteAsync(arguments, _manager.Service, token);
+    }
+}

--- a/src/TaskHub.Server/PluginLoadContext.cs
+++ b/src/TaskHub.Server/PluginLoadContext.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace TaskHub.Server;
+
+public class PluginLoadContext : AssemblyLoadContext
+{
+    private readonly AssemblyDependencyResolver _resolver;
+
+    public PluginLoadContext(string pluginPath) : base(isCollectible: true)
+    {
+        _resolver = new AssemblyDependencyResolver(pluginPath);
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        var path = _resolver.ResolveAssemblyToPath(assemblyName);
+        if (path != null)
+        {
+            return LoadFromAssemblyPath(path);
+        }
+        return null;
+    }
+
+    protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+    {
+        var path = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+        if (path != null)
+        {
+            return LoadUnmanagedDllFromPath(path);
+        }
+        return IntPtr.Zero;
+    }
+}

--- a/src/TaskHub.Server/PluginManager.cs
+++ b/src/TaskHub.Server/PluginManager.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TaskHub.Abstractions;
+
+namespace TaskHub.Server;
+
+public class PluginManager
+{
+    private readonly Dictionary<string, (ICommandHandler Handler, PluginLoadContext Context, string AssemblyPath)> _handlers = new();
+    private readonly List<string> _assemblies = new();
+    private IServicePlugin? _service;
+
+    public void Load(string root)
+    {
+        var serviceRoot = Path.Combine(root, "services");
+        if (Directory.Exists(serviceRoot))
+        {
+            foreach (var dir in Directory.GetDirectories(serviceRoot))
+            {
+                var dll = Directory.GetFiles(dir, "*.dll", SearchOption.TopDirectoryOnly).FirstOrDefault();
+                if (dll == null) continue;
+                var context = new PluginLoadContext(dll);
+                var asm = context.LoadFromAssemblyPath(dll);
+                var type = asm.GetTypes().FirstOrDefault(t => typeof(IServicePlugin).IsAssignableFrom(t) && !t.IsAbstract);
+                if (type != null)
+                {
+                    _service = (IServicePlugin)Activator.CreateInstance(type)!;
+                    _assemblies.Add(dll);
+                    break;
+                }
+            }
+        }
+
+        var handlerRoot = Path.Combine(root, "handlers");
+        if (Directory.Exists(handlerRoot))
+        {
+            foreach (var dir in Directory.GetDirectories(handlerRoot))
+            {
+                var dll = Directory.GetFiles(dir, "*.dll", SearchOption.TopDirectoryOnly).FirstOrDefault();
+                if (dll == null) continue;
+                var context = new PluginLoadContext(dll);
+                var asm = context.LoadFromAssemblyPath(dll);
+                var type = asm.GetTypes().FirstOrDefault(t => typeof(ICommandHandler).IsAssignableFrom(t) && !t.IsAbstract);
+                if (type == null) continue;
+                var handler = (ICommandHandler)Activator.CreateInstance(type)!;
+                _handlers[handler.Name] = (handler, context, dll);
+                _assemblies.Add(dll);
+            }
+        }
+    }
+
+    public IEnumerable<string> LoadedAssemblies => _assemblies;
+
+    public ICommandHandler? GetHandler(string name) => _handlers.TryGetValue(name, out var value) ? value.Handler : null;
+
+    public IServicePlugin Service => _service ?? throw new InvalidOperationException("Service plugin not loaded");
+}

--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -1,0 +1,31 @@
+using Hangfire;
+using Hangfire.MemoryStorage;
+using TaskHub.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHangfire(config => config.UseMemoryStorage());
+builder.Services.AddHangfireServer();
+
+builder.Services.AddSingleton<PluginManager>();
+builder.Services.AddSingleton<CommandExecutor>();
+
+var app = builder.Build();
+
+var plugins = app.Services.GetRequiredService<PluginManager>();
+plugins.Load(Path.Combine(AppContext.BaseDirectory, "plugins"));
+
+app.MapGet("/dlls", () => plugins.LoadedAssemblies);
+
+app.MapPost("/commands/{handler}", (string handler, string? arg, IBackgroundJobClient client) =>
+{
+    var jobId = client.Enqueue<CommandExecutor>(exec => exec.Execute(handler, arg ?? string.Empty, CancellationToken.None));
+    return Results.Ok(jobId);
+});
+
+app.MapPost("/commands/{id}/cancel", (string id, IBackgroundJobClient client) =>
+{
+    return client.Delete(id) ? Results.Ok() : Results.NotFound();
+});
+
+app.Run();

--- a/src/TaskHub.Server/TaskHub.Server.csproj
+++ b/src/TaskHub.Server/TaskHub.Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.37" />
+    <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\\..\\plugins\\**\\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Add Hangfire-based server hosting a plugin system for command handlers and service plugins
- Implement runtime plugin loader with assembly isolation and minimal API endpoints
- Provide example HTTP service plugin and echo command handler

## Testing
- `dotnet build` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a64aeeeb208321b1f309fecd34f9a4