### PR TITLE
refactor: move command execution to command objects

### DIFF
--- a/plugins/handlers/EchoHandler/EchoCommand.cs
+++ b/plugins/handlers/EchoHandler/EchoCommand.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace EchoHandler;
+
+public class EchoCommand : ICommand
+{
+    public EchoCommand(EchoRequest request)
+    {
+        Request = request;
+    }
+
+    public EchoRequest Request { get; }
+
+    public async Task ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    {
+        var client = (HttpClient)service.GetService();
+        var result = await client.GetStringAsync(Request.Resource, cancellationToken);
+        Console.WriteLine($"Echo: {result}");
+    }
+}
+

--- a/plugins/handlers/EchoHandler/EchoCommandHandler.cs
+++ b/plugins/handlers/EchoHandler/EchoCommandHandler.cs
@@ -1,24 +1,19 @@
-using System;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 using TaskHub.Abstractions;
 
 namespace EchoHandler;
 
-public class EchoCommandHandler : ICommandHandler
+public class EchoCommandHandler : ICommandHandler<EchoCommand>
 {
     public IReadOnlyCollection<string> Commands => new[] { "echo" };
     public string ServiceName => "http";
 
-    public async Task ExecuteAsync(JsonElement payload, IServicePlugin service, CancellationToken cancellationToken)
+    public EchoCommand Create(JsonElement payload)
     {
-        var resource = payload.GetProperty("resource").GetString() ?? string.Empty;
-        var client = (HttpClient)service.GetService();
-        var result = await client.GetStringAsync(resource, cancellationToken);
-        Console.WriteLine($"Echo: {result}");
+        var request = JsonSerializer.Deserialize<EchoRequest>(payload.GetRawText())
+                      ?? new EchoRequest();
+        return new EchoCommand(request);
     }
 }
 

--- a/plugins/handlers/EchoHandler/EchoRequest.cs
+++ b/plugins/handlers/EchoHandler/EchoRequest.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace EchoHandler;
+
+public class EchoRequest
+{
+    [JsonPropertyName("resource")]
+    public string Resource { get; set; } = string.Empty;
+}
+

--- a/src/TaskHub.Abstractions/Interfaces/ICommand.cs
+++ b/src/TaskHub.Abstractions/Interfaces/ICommand.cs
@@ -1,0 +1,10 @@
+namespace TaskHub.Abstractions;
+
+using System.Threading;
+using System.Threading.Tasks;
+
+public interface ICommand
+{
+    Task ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken);
+}
+

--- a/src/TaskHub.Abstractions/Interfaces/ICommandHandler.cs
+++ b/src/TaskHub.Abstractions/Interfaces/ICommandHandler.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace TaskHub.Abstractions;
 
@@ -9,5 +7,10 @@ public interface ICommandHandler
 {
     IReadOnlyCollection<string> Commands { get; }
     string ServiceName { get; }
-    Task ExecuteAsync(JsonElement payload, IServicePlugin service, CancellationToken cancellationToken);
+    ICommand Create(JsonElement payload);
+}
+
+public interface ICommandHandler<out TCommand> : ICommandHandler where TCommand : ICommand
+{
+    new TCommand Create(JsonElement payload);
 }

--- a/src/TaskHub.Server/CommandExecutor.cs
+++ b/src/TaskHub.Server/CommandExecutor.cs
@@ -24,6 +24,7 @@ public class CommandExecutor
         }
 
         var service = _manager.GetService(handler.ServiceName);
-        await handler.ExecuteAsync(payload, service, token);
+        var cmd = handler.Create(payload);
+        await cmd.ExecuteAsync(service, token);
     }
 }


### PR DESCRIPTION
## Summary
- add ICommand interface to encapsulate command execution
- refactor handlers to create commands instead of executing payload
- update command executor and Echo plugin to use command execution
- deserialize Echo handler payload into object instead of single property

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a75557ce1c83219f465867e57b5fca