### PR TITLE
Add NSwag and move shared types to abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ dotnet run --project src/TaskHub.Server
 
 The server exposes a minimal API:
 
-- `POST /commands/{handler}?arg=value` – enqueue a command handled by a plugin.
+- `POST /commands/{handler}?arg=value` – enqueue a command handled by a plugin and return the job id with metadata.
 - `POST /commands/{id}/cancel` – cancel a queued job.
 - `GET /dlls` – list loaded plugin assemblies.
 
+An OpenAPI/Swagger UI powered by NSwag is available at `/swagger`.
+
 Plugins must be compiled and copied under the `plugins` directory as described in the project.
+The `TaskHub.Abstractions` project contains shared interfaces and result types and can be packaged as a NuGet
+dependency for plugin development.

--- a/src/TaskHub.Abstractions/EnqueuedCommandResult.cs
+++ b/src/TaskHub.Abstractions/EnqueuedCommandResult.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace TaskHub.Abstractions;
+
+public record EnqueuedCommandResult(string Id, string Command, DateTimeOffset EnqueuedAt);

--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -4,6 +4,7 @@ using Hangfire.Dashboard;
 using Microsoft.Extensions.Configuration;
 using System.Text.Json;
 using TaskHub.Server;
+using TaskHub.Abstractions;
 using Microsoft.Extensions.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -20,8 +21,12 @@ builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
 builder.Services.AddSingleton<PluginManager>();
 builder.Services.AddSingleton<CommandExecutor>();
+builder.Services.AddOpenApiDocument();
 
 var app = builder.Build();
+
+app.UseOpenApi();
+app.UseSwaggerUi3();
 
 app.UseHangfireDashboard("/hangfire", new DashboardOptions
 {
@@ -36,8 +41,8 @@ app.MapGet("/dlls", () => plugins.LoadedAssemblies);
 app.MapPost("/commands/{command}", (string command, JsonElement payload, IBackgroundJobClient client) =>
 {
     var jobId = client.Enqueue<CommandExecutor>(exec => exec.Execute(command, payload, CancellationToken.None));
-    return Results.Ok(jobId);
-});
+    return Results.Ok(new EnqueuedCommandResult(jobId, command, DateTimeOffset.UtcNow));
+}).Produces<EnqueuedCommandResult>();
 
 app.MapPost("/commands/{id}/cancel", (string id, IBackgroundJobClient client) =>
 {

--- a/src/TaskHub.Server/TaskHub.Server.csproj
+++ b/src/TaskHub.Server/TaskHub.Server.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.37" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.1" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.20.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\\..\\plugins\\**\\*.*">


### PR DESCRIPTION
## Summary
- integrate NSwag and expose Swagger UI
- return job id and metadata when enqueuing commands
- move EnqueuedCommandResult to abstractions for plugin NuGet

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a757fbe1188321969ba830d59ff102