### PR TITLE
Add periodic temp cleanup handler

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -14,6 +14,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MsGraphServicePlugin", "plu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActiveDirectoryServicePlugin", "plugins/services/ActiveDirectoryServicePlugin/ActiveDirectoryServicePlugin.csproj", "{F158A15A-29A1-4385-9BEC-BDB5DE89B748}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CleanTempHandler", "plugins/handlers/CleanTempHandler/CleanTempHandler.csproj", "{C71448A2-77B8-47BC-B1C2-AEBA72E4464C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileSystemServicePlugin", "plugins/services/FileSystemServicePlugin/FileSystemServicePlugin.csproj", "{3C4176EF-E2B9-4311-92D5-B1BA60C226B3}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -44,6 +48,14 @@ Global
         {F158A15A-29A1-4385-9BEC-BDB5DE89B748}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {F158A15A-29A1-4385-9BEC-BDB5DE89B748}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {F158A15A-29A1-4385-9BEC-BDB5DE89B748}.Release|Any CPU.Build.0 = Release|Any CPU
+        {C71448A2-77B8-47BC-B1C2-AEBA72E4464C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {C71448A2-77B8-47BC-B1C2-AEBA72E4464C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {C71448A2-77B8-47BC-B1C2-AEBA72E4464C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {C71448A2-77B8-47BC-B1C2-AEBA72E4464C}.Release|Any CPU.Build.0 = Release|Any CPU
+        {3C4176EF-E2B9-4311-92D5-B1BA60C226B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3C4176EF-E2B9-4311-92D5-B1BA60C226B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3C4176EF-E2B9-4311-92D5-B1BA60C226B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3C4176EF-E2B9-4311-92D5-B1BA60C226B3}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace CleanTempHandler;
+
+public class CleanTempCommand : ICommand
+{
+    private readonly string _path;
+
+    public CleanTempCommand(string path)
+    {
+        _path = path;
+    }
+
+    public Task ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    {
+        var cleaner = (Action<string>)service.GetService();
+        cleaner(_path);
+        return Task.CompletedTask;
+    }
+}

--- a/plugins/handlers/CleanTempHandler/CleanTempCommandHandler.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommandHandler.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace CleanTempHandler;
+
+public class CleanTempCommandHandler : ICommandHandler<CleanTempCommand>
+{
+    public IReadOnlyCollection<string> Commands => new[] { "clean-temp" };
+    public string ServiceName => "filesystem";
+
+    public CleanTempCommand Create(JsonElement payload)
+    {
+        var path = payload.TryGetProperty("path", out var element) ? element.GetString() : @"C:\\temp22";
+        return new CleanTempCommand(path ?? @"C:\\temp22");
+    }
+}

--- a/plugins/handlers/CleanTempHandler/CleanTempHandler.csproj
+++ b/plugins/handlers/CleanTempHandler/CleanTempHandler.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/plugins/services/FileSystemServicePlugin/FileSystemService.cs
+++ b/plugins/services/FileSystemServicePlugin/FileSystemService.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using TaskHub.Abstractions;
+
+namespace FileSystemServicePlugin;
+
+public class FileSystemServicePlugin : IServicePlugin
+{
+    public string Name => "filesystem";
+
+    public object GetService() => (Action<string>)CleanDirectory;
+
+    private static void CleanDirectory(string path)
+    {
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+
+        foreach (var file in Directory.GetFiles(path))
+        {
+            File.Delete(file);
+        }
+
+        foreach (var directory in Directory.GetDirectories(path))
+        {
+            Directory.Delete(directory, true);
+        }
+    }
+}

--- a/plugins/services/FileSystemServicePlugin/FileSystemServicePlugin.csproj
+++ b/plugins/services/FileSystemServicePlugin/FileSystemServicePlugin.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -36,6 +36,12 @@ app.UseHangfireDashboard("/hangfire", new DashboardOptions
 var plugins = app.Services.GetRequiredService<PluginManager>();
 plugins.Load(Path.Combine(AppContext.BaseDirectory, "plugins"));
 
+var payload = JsonSerializer.Deserialize<JsonElement>("{}");
+RecurringJob.AddOrUpdate<CommandExecutor>(
+    "clean-temp",
+    exec => exec.Execute("clean-temp", payload, CancellationToken.None),
+    Cron.HourInterval(7));
+
 app.MapGet("/dlls", () => plugins.LoadedAssemblies);
 
 app.MapPost("/commands/{command}", (string command, JsonElement payload, IBackgroundJobClient client) =>


### PR DESCRIPTION
## Summary
- add filesystem service plugin for directory cleanup
- implement clean-temp handler utilizing filesystem service
- schedule clean-temp command every 7 hours via Hangfire

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7887f0584832190fc534b378c5610