### PR TITLE
Add delete-folder command to CleanTempHandler

### DIFF
--- a/plugins/handlers/CleanTempHandler/CleanTempCommandHandler.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommandHandler.cs
@@ -4,14 +4,25 @@ using TaskHub.Abstractions;
 
 namespace CleanTempHandler;
 
-public class CleanTempCommandHandler : ICommandHandler<CleanTempCommand>
+public class CleanTempCommandHandler :
+    ICommandHandler<CleanTempCommand>,
+    ICommandHandler<DeleteFolderCommand>
 {
-    public IReadOnlyCollection<string> Commands => new[] { "clean-temp" };
+    public IReadOnlyCollection<string> Commands => new[] { "clean-temp", "delete-folder" };
     public string ServiceName => "filesystem";
 
-    public CleanTempCommand Create(JsonElement payload)
+    CleanTempCommand ICommandHandler<CleanTempCommand>.Create(JsonElement payload)
     {
         var path = payload.TryGetProperty("path", out var element) ? element.GetString() : @"C:\\temp22";
         return new CleanTempCommand(path ?? @"C:\\temp22");
     }
+
+    DeleteFolderCommand ICommandHandler<DeleteFolderCommand>.Create(JsonElement payload)
+    {
+        var path = payload.TryGetProperty("path", out var element) ? element.GetString() : @"C:\\temp22";
+        return new DeleteFolderCommand(path ?? @"C:\\temp22");
+    }
+
+    public ICommand Create(JsonElement payload) =>
+        ((ICommandHandler<CleanTempCommand>)this).Create(payload);
 }

--- a/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
+++ b/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace CleanTempHandler;
+
+public class DeleteFolderCommand : ICommand
+{
+    private readonly string _path;
+
+    public DeleteFolderCommand(string path)
+    {
+        _path = path;
+    }
+
+    public Task ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    {
+        if (Directory.Exists(_path))
+        {
+            Directory.Delete(_path, true);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DeleteFolderCommand to remove directories recursively
- handle `delete-folder` command within existing CleanTempCommandHandler

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a78ae39f1c83218dc106ea34ed3720