### PR TITLE
Support chaining command execution

### DIFF
--- a/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using TaskHub.Abstractions;
@@ -14,10 +15,10 @@ public class CleanTempCommand : ICommand
         _path = path;
     }
 
-    public Task ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
     {
         var cleaner = (Action<string>)service.GetService();
         cleaner(_path);
-        return Task.CompletedTask;
+        return Task.FromResult(JsonSerializer.SerializeToElement(_path));
     }
 }

--- a/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
+++ b/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using TaskHub.Abstractions;
@@ -14,14 +15,14 @@ public class DeleteFolderCommand : ICommand
         _path = path;
     }
 
-    public Task ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
     {
         if (Directory.Exists(_path))
         {
             Directory.Delete(_path, true);
         }
 
-        return Task.CompletedTask;
+        return Task.FromResult(JsonSerializer.SerializeToElement(_path));
     }
 }
 

--- a/plugins/handlers/EchoHandler/EchoCommand.cs
+++ b/plugins/handlers/EchoHandler/EchoCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using TaskHub.Abstractions;
@@ -15,11 +16,12 @@ public class EchoCommand : ICommand
 
     public EchoRequest Request { get; }
 
-    public async Task ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public async Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
     {
         var client = (HttpClient)service.GetService();
         var result = await client.GetStringAsync(Request.Resource, cancellationToken);
         Console.WriteLine($"Echo: {result}");
+        return JsonSerializer.SerializeToElement(result);
     }
 }
 

--- a/src/TaskHub.Abstractions/Interfaces/ICommand.cs
+++ b/src/TaskHub.Abstractions/Interfaces/ICommand.cs
@@ -2,9 +2,10 @@ namespace TaskHub.Abstractions;
 
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text.Json;
 
 public interface ICommand
 {
-    Task ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken);
+    Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken);
 }
 

--- a/src/TaskHub.Server/CommandChainRequest.cs
+++ b/src/TaskHub.Server/CommandChainRequest.cs
@@ -1,0 +1,5 @@
+using System.Text.Json;
+
+namespace TaskHub.Server;
+
+public record CommandChainRequest(string[] Commands, JsonElement Payload);

--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -55,5 +55,11 @@ app.MapPost("/commands/{id}/cancel", (string id, IBackgroundJobClient client) =>
     return client.Delete(id) ? Results.Ok() : Results.NotFound();
 });
 
+app.MapPost("/commands/chain", async (CommandChainRequest request, CommandExecutor executor) =>
+{
+    var result = await executor.ExecuteChain(request.Commands, request.Payload, CancellationToken.None);
+    return Results.Json(result);
+}).Produces<JsonElement>();
+
 app.Run();
 


### PR DESCRIPTION
## Summary
- allow commands to return `JsonElement` results
- add CommandExecutor chain execution that passes data between commands
- expose `/commands/chain` endpoint for running sequential command chains
- update sample plugin commands accordingly

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a79015b9c0832190d9b55d36b67055