### PR TITLE
Unify command execution endpoint and add job status API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ dotnet run --project src/TaskHub.Server
 
 The server exposes a minimal API:
 
-- `POST /commands/{handler}?arg=value` – enqueue a command handled by a plugin and return the job id with metadata.
+- `POST /commands` – enqueue one or more commands handled by plugins. The body accepts a JSON payload with a
+  `commands` array and an optional `payload` object. Returns the job id with metadata.
+- `GET /commands/{id}` – retrieve the status of a previously enqueued job.
 - `POST /commands/{id}/cancel` – cancel a queued job.
 - `GET /dlls` – list loaded plugin assemblies.
 

--- a/src/TaskHub.Abstractions/CommandStatusResult.cs
+++ b/src/TaskHub.Abstractions/CommandStatusResult.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace TaskHub.Abstractions;
+
+/// <summary>
+/// Represents the status of an enqueued command.
+/// </summary>
+/// <param name="Id">Identifier of the background job.</param>
+/// <param name="Status">Current status/state of the job.</param>
+public record CommandStatusResult(string Id, string Status);

--- a/src/TaskHub.Abstractions/EnqueuedCommandResult.cs
+++ b/src/TaskHub.Abstractions/EnqueuedCommandResult.cs
@@ -2,4 +2,10 @@ using System;
 
 namespace TaskHub.Abstractions;
 
-public record EnqueuedCommandResult(string Id, string Command, DateTimeOffset EnqueuedAt);
+/// <summary>
+/// Result returned when a command or chain of commands is enqueued.
+/// </summary>
+/// <param name="Id">Identifier of the background job.</param>
+/// <param name="Commands">Commands that will be executed.</param>
+/// <param name="EnqueuedAt">Timestamp when the job was enqueued.</param>
+public record EnqueuedCommandResult(string Id, string[] Commands, DateTimeOffset EnqueuedAt);


### PR DESCRIPTION
## Summary
- replace single/chain endpoints with unified `POST /commands` accepting a commands array
- provide `GET /commands/{id}` for job status queries
- expose status and enqueue result records and update documentation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a798978f6c8321a95d37a04259b33a