### PR TITLE
refactor: require request objects for handler commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ An OpenAPI/Swagger UI powered by NSwag is available at `/swagger`.
 Plugins must be compiled and copied under the `plugins` directory as described in the project.
 The `TaskHub.Abstractions` project contains shared interfaces and result types and can be packaged as a NuGet
 dependency for plugin development.
+
+## ESLint
+
+For JavaScript or TypeScript plugins, run ESLint to ensure code quality:
+
+```bash
+npm test
+```
+
+If no `test` script is defined, you can run ESLint directly:
+
+```bash
+npx eslint .
+```
+

--- a/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
@@ -8,17 +8,17 @@ namespace CleanTempHandler;
 
 public class CleanTempCommand : ICommand
 {
-    private readonly string _path;
-
-    public CleanTempCommand(string path)
+    public CleanTempCommand(CleanTempRequest request)
     {
-        _path = path;
+        Request = request;
     }
+
+    public CleanTempRequest Request { get; }
 
     public Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
     {
         var cleaner = (Action<string>)service.GetService();
-        cleaner(_path);
-        return Task.FromResult(JsonSerializer.SerializeToElement(_path));
+        cleaner(Request.Path);
+        return Task.FromResult(JsonSerializer.SerializeToElement(Request.Path));
     }
 }

--- a/plugins/handlers/CleanTempHandler/CleanTempCommandHandler.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommandHandler.cs
@@ -13,14 +13,16 @@ public class CleanTempCommandHandler :
 
     CleanTempCommand ICommandHandler<CleanTempCommand>.Create(JsonElement payload)
     {
-        var path = payload.TryGetProperty("path", out var element) ? element.GetString() : @"C:\\temp22";
-        return new CleanTempCommand(path ?? @"C:\\temp22");
+        var request = JsonSerializer.Deserialize<CleanTempRequest>(payload.GetRawText())
+                      ?? new CleanTempRequest();
+        return new CleanTempCommand(request);
     }
 
     DeleteFolderCommand ICommandHandler<DeleteFolderCommand>.Create(JsonElement payload)
     {
-        var path = payload.TryGetProperty("path", out var element) ? element.GetString() : @"C:\\temp22";
-        return new DeleteFolderCommand(path ?? @"C:\\temp22");
+        var request = JsonSerializer.Deserialize<DeleteFolderRequest>(payload.GetRawText())
+                      ?? new DeleteFolderRequest();
+        return new DeleteFolderCommand(request);
     }
 
     public ICommand Create(JsonElement payload) =>

--- a/plugins/handlers/CleanTempHandler/CleanTempRequest.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace CleanTempHandler;
+
+public class CleanTempRequest
+{
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = @"C:\\temp22";
+}

--- a/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
+++ b/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
@@ -8,21 +8,21 @@ namespace CleanTempHandler;
 
 public class DeleteFolderCommand : ICommand
 {
-    private readonly string _path;
-
-    public DeleteFolderCommand(string path)
+    public DeleteFolderCommand(DeleteFolderRequest request)
     {
-        _path = path;
+        Request = request;
     }
+
+    public DeleteFolderRequest Request { get; }
 
     public Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
     {
-        if (Directory.Exists(_path))
+        if (Directory.Exists(Request.Path))
         {
-            Directory.Delete(_path, true);
+            Directory.Delete(Request.Path, true);
         }
 
-        return Task.FromResult(JsonSerializer.SerializeToElement(_path));
+        return Task.FromResult(JsonSerializer.SerializeToElement(Request.Path));
     }
 }
 

--- a/plugins/handlers/CleanTempHandler/DeleteFolderRequest.cs
+++ b/plugins/handlers/CleanTempHandler/DeleteFolderRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace CleanTempHandler;
+
+public class DeleteFolderRequest
+{
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = @"C:\\temp22";
+}


### PR DESCRIPTION
## Summary
- document how to run ESLint checks using `npm test` or `npx eslint .`
- refactor CleanTemp handler commands to accept typed request objects

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*
- `npx eslint .` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa30ffa3d08321ae77599c62f1ab10