### PR TITLE
Add basic PluginManager unit tests

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -18,6 +18,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CleanTempHandler", "plugins
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileSystemServicePlugin", "plugins/services/FileSystemServicePlugin/FileSystemServicePlugin.csproj", "{3C4176EF-E2B9-4311-92D5-B1BA60C226B3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.Server.Tests", "tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj", "{FF3F77A7-CF65-4B57-8099-1D583FFE64B3}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
         {3C4176EF-E2B9-4311-92D5-B1BA60C226B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {3C4176EF-E2B9-4311-92D5-B1BA60C226B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {3C4176EF-E2B9-4311-92D5-B1BA60C226B3}.Release|Any CPU.Build.0 = Release|Any CPU
+        {FF3F77A7-CF65-4B57-8099-1D583FFE64B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {FF3F77A7-CF65-4B57-8099-1D583FFE64B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {FF3F77A7-CF65-4B57-8099-1D583FFE64B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {FF3F77A7-CF65-4B57-8099-1D583FFE64B3}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/tests/TaskHub.Server.Tests/PluginManagerTests.cs
+++ b/tests/TaskHub.Server.Tests/PluginManagerTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using TaskHub.Abstractions;
+using TaskHub.Server;
+using Xunit;
+
+namespace TaskHub.Server.Tests;
+
+public class PluginManagerTests
+{
+    private static PluginManager CreateManager()
+    {
+        var services = new ServiceCollection();
+        var provider = services.BuildServiceProvider();
+        return new PluginManager(provider);
+    }
+
+    [Fact]
+    public void GetHandler_ReturnsInstance_WhenRegistered()
+    {
+        var manager = CreateManager();
+        var handlersField = typeof(PluginManager).GetField("_handlers", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var handlers = (Dictionary<string, (Type HandlerType, PluginLoadContext Context, string AssemblyPath)>)handlersField.GetValue(manager)!;
+        var path = typeof(StubHandler).Assembly.Location;
+        handlers["stub"] = (typeof(StubHandler), new PluginLoadContext(path), path);
+
+        var handler = manager.GetHandler("stub");
+
+        Assert.NotNull(handler);
+        Assert.IsType<StubHandler>(handler);
+    }
+
+    [Fact]
+    public void GetHandler_ReturnsNull_ForUnknownCommand()
+    {
+        var manager = CreateManager();
+        var handler = manager.GetHandler("missing");
+        Assert.Null(handler);
+    }
+
+    [Fact]
+    public void GetService_ReturnsInstance_WhenRegistered()
+    {
+        var manager = CreateManager();
+        var servicesField = typeof(PluginManager).GetField("_services", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var servicesDict = (Dictionary<string, (Type ServiceType, PluginLoadContext Context, string AssemblyPath)>)servicesField.GetValue(manager)!;
+        var path = typeof(StubServicePlugin).Assembly.Location;
+        servicesDict["Stub"] = (typeof(StubServicePlugin), new PluginLoadContext(path), path);
+
+        var service = manager.GetService("Stub");
+
+        Assert.IsType<StubServicePlugin>(service);
+    }
+
+    [Fact]
+    public void GetService_Throws_WhenNotLoaded()
+    {
+        var manager = CreateManager();
+        Assert.Throws<InvalidOperationException>(() => manager.GetService("unknown"));
+    }
+
+    private class StubServicePlugin : IServicePlugin
+    {
+        public string Name => "Stub";
+        public object GetService() => new object();
+    }
+
+    private class StubCommand : ICommand
+    {
+        public System.Threading.Tasks.Task<System.Text.Json.JsonElement> ExecuteAsync(IServicePlugin service, System.Threading.CancellationToken cancellationToken)
+        {
+            return System.Threading.Tasks.Task.FromResult(System.Text.Json.JsonDocument.Parse("{}" ).RootElement);
+        }
+    }
+
+    private class StubHandler : ICommandHandler<StubCommand>
+    {
+        public IReadOnlyCollection<string> Commands => new[] { "stub" };
+        public string ServiceName => "Stub";
+        public StubCommand Create(System.Text.Json.JsonElement payload) => new StubCommand();
+        ICommand ICommandHandler.Create(System.Text.Json.JsonElement payload) => Create(payload);
+    }
+}

--- a/tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj
+++ b/tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\src\\TaskHub.Server\\TaskHub.Server.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add xUnit project with tests for PluginManager
- include new test project in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa407c29e88321b76d966002e65925