### PR TITLE
Add test projects for TaskHub plugins

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -20,6 +20,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileSystemServicePlugin", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.Server.Tests", "tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj", "{FF3F77A7-CF65-4B57-8099-1D583FFE64B3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EchoHandler.Tests", "tests/EchoHandler.Tests/EchoHandler.Tests.csproj", "{8054CBD6-946B-4D55-BDC5-4E6F9049C5A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CleanTempHandler.Tests", "tests/CleanTempHandler.Tests/CleanTempHandler.Tests.csproj", "{CDB3E180-A782-4F7D-BC41-33B11BB40669}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileSystemServicePlugin.Tests", "tests/FileSystemServicePlugin.Tests/FileSystemServicePlugin.Tests.csproj", "{5110AA29-618F-497E-8D52-166AAC86EFE3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpServicePlugin.Tests", "tests/HttpServicePlugin.Tests/HttpServicePlugin.Tests.csproj", "{00A7A76B-BB85-40A6-8746-F8669B7A49A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActiveDirectoryServicePlugin.Tests", "tests/ActiveDirectoryServicePlugin.Tests/ActiveDirectoryServicePlugin.Tests.csproj", "{30C007D9-21C4-428B-875B-026888436985}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MsGraphServicePlugin.Tests", "tests/MsGraphServicePlugin.Tests/MsGraphServicePlugin.Tests.csproj", "{28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -62,6 +74,30 @@ Global
         {FF3F77A7-CF65-4B57-8099-1D583FFE64B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {FF3F77A7-CF65-4B57-8099-1D583FFE64B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {FF3F77A7-CF65-4B57-8099-1D583FFE64B3}.Release|Any CPU.Build.0 = Release|Any CPU
+        {8054CBD6-946B-4D55-BDC5-4E6F9049C5A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {8054CBD6-946B-4D55-BDC5-4E6F9049C5A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {8054CBD6-946B-4D55-BDC5-4E6F9049C5A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {8054CBD6-946B-4D55-BDC5-4E6F9049C5A6}.Release|Any CPU.Build.0 = Release|Any CPU
+        {CDB3E180-A782-4F7D-BC41-33B11BB40669}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {CDB3E180-A782-4F7D-BC41-33B11BB40669}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {CDB3E180-A782-4F7D-BC41-33B11BB40669}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {CDB3E180-A782-4F7D-BC41-33B11BB40669}.Release|Any CPU.Build.0 = Release|Any CPU
+        {5110AA29-618F-497E-8D52-166AAC86EFE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {5110AA29-618F-497E-8D52-166AAC86EFE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {5110AA29-618F-497E-8D52-166AAC86EFE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {5110AA29-618F-497E-8D52-166AAC86EFE3}.Release|Any CPU.Build.0 = Release|Any CPU
+        {00A7A76B-BB85-40A6-8746-F8669B7A49A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {00A7A76B-BB85-40A6-8746-F8669B7A49A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {00A7A76B-BB85-40A6-8746-F8669B7A49A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {00A7A76B-BB85-40A6-8746-F8669B7A49A6}.Release|Any CPU.Build.0 = Release|Any CPU
+        {30C007D9-21C4-428B-875B-026888436985}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {30C007D9-21C4-428B-875B-026888436985}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {30C007D9-21C4-428B-875B-026888436985}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {30C007D9-21C4-428B-875B-026888436985}.Release|Any CPU.Build.0 = Release|Any CPU
+        {28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/tests/ActiveDirectoryServicePlugin.Tests/ActiveDirectoryServicePlugin.Tests.csproj
+++ b/tests/ActiveDirectoryServicePlugin.Tests/ActiveDirectoryServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\ActiveDirectoryServicePlugin\\ActiveDirectoryServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/ActiveDirectoryServicePlugin.Tests/ActiveDirectoryServicePluginTests.cs
+++ b/tests/ActiveDirectoryServicePlugin.Tests/ActiveDirectoryServicePluginTests.cs
@@ -1,0 +1,17 @@
+using ActiveDirectoryServicePlugin;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace ActiveDirectoryServicePlugin.Tests;
+
+public class ActiveDirectoryServicePluginTests
+{
+    [Fact]
+    public void NameIsActiveDirectory()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        var plugin = new ActiveDirectoryServicePlugin(config, NullLogger<ActiveDirectoryServicePlugin>.Instance);
+        Assert.Equal("activedirectory", plugin.Name);
+    }
+}

--- a/tests/CleanTempHandler.Tests/CleanTempCommandHandlerTests.cs
+++ b/tests/CleanTempHandler.Tests/CleanTempCommandHandlerTests.cs
@@ -1,0 +1,16 @@
+using CleanTempHandler;
+using Xunit;
+
+namespace CleanTempHandler.Tests;
+
+public class CleanTempCommandHandlerTests
+{
+    [Fact]
+    public void CommandsIncludeExpectedValues()
+    {
+        var handler = new CleanTempCommandHandler();
+        Assert.Contains("clean-temp", handler.Commands);
+        Assert.Contains("delete-folder", handler.Commands);
+        Assert.Equal("filesystem", handler.ServiceName);
+    }
+}

--- a/tests/CleanTempHandler.Tests/CleanTempHandler.Tests.csproj
+++ b/tests/CleanTempHandler.Tests/CleanTempHandler.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\CleanTempHandler\\CleanTempHandler.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/EchoHandler.Tests/EchoCommandHandlerTests.cs
+++ b/tests/EchoHandler.Tests/EchoCommandHandlerTests.cs
@@ -1,0 +1,15 @@
+using EchoHandler;
+using Xunit;
+
+namespace EchoHandler.Tests;
+
+public class EchoCommandHandlerTests
+{
+    [Fact]
+    public void CommandsIncludeEcho()
+    {
+        var handler = new EchoCommandHandler();
+        Assert.Contains("echo", handler.Commands);
+        Assert.Equal("http", handler.ServiceName);
+    }
+}

--- a/tests/EchoHandler.Tests/EchoHandler.Tests.csproj
+++ b/tests/EchoHandler.Tests/EchoHandler.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\EchoHandler\\EchoHandler.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/FileSystemServicePlugin.Tests/FileSystemServicePlugin.Tests.csproj
+++ b/tests/FileSystemServicePlugin.Tests/FileSystemServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\FileSystemServicePlugin\\FileSystemServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/FileSystemServicePlugin.Tests/FileSystemServicePluginTests.cs
+++ b/tests/FileSystemServicePlugin.Tests/FileSystemServicePluginTests.cs
@@ -1,0 +1,14 @@
+using FileSystemServicePlugin;
+using Xunit;
+
+namespace FileSystemServicePlugin.Tests;
+
+public class FileSystemServicePluginTests
+{
+    [Fact]
+    public void NameIsFilesystem()
+    {
+        var plugin = new FileSystemServicePlugin();
+        Assert.Equal("filesystem", plugin.Name);
+    }
+}

--- a/tests/HttpServicePlugin.Tests/HttpServicePlugin.Tests.csproj
+++ b/tests/HttpServicePlugin.Tests/HttpServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\HttpServicePlugin\\HttpServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/HttpServicePlugin.Tests/HttpServicePluginTests.cs
+++ b/tests/HttpServicePlugin.Tests/HttpServicePluginTests.cs
@@ -1,0 +1,15 @@
+using HttpServicePlugin;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace HttpServicePlugin.Tests;
+
+public class HttpServicePluginTests
+{
+    [Fact]
+    public void NameIsHttp()
+    {
+        var plugin = new HttpServicePlugin(NullLogger<HttpServicePlugin>.Instance);
+        Assert.Equal("http", plugin.Name);
+    }
+}

--- a/tests/MsGraphServicePlugin.Tests/MsGraphServicePlugin.Tests.csproj
+++ b/tests/MsGraphServicePlugin.Tests/MsGraphServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\MsGraphServicePlugin\\MsGraphServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/MsGraphServicePlugin.Tests/MsGraphServicePluginTests.cs
+++ b/tests/MsGraphServicePlugin.Tests/MsGraphServicePluginTests.cs
@@ -1,0 +1,15 @@
+using MsGraphServicePlugin;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace MsGraphServicePlugin.Tests;
+
+public class MsGraphServicePluginTests
+{
+    [Fact]
+    public void NameIsMsGraph()
+    {
+        var plugin = (MsGraphServicePlugin)FormatterServices.GetUninitializedObject(typeof(MsGraphServicePlugin));
+        Assert.Equal("msgraph", plugin.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit-based test projects for every handler and service plugin
- include the new test projects in the solution

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68aaba8862c08321a798d7414fa5d427