### PR TITLE
Add registry service plugin

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -18,6 +18,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CleanTempHandler", "plugins
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FileSystemServicePlugin", "plugins/services/FileSystemServicePlugin/FileSystemServicePlugin.csproj", "{3C4176EF-E2B9-4311-92D5-B1BA60C226B3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegistryServicePlugin", "plugins/services/RegistryServicePlugin/RegistryServicePlugin.csproj", "{17CC2649-0CF3-451D-9BA2-F73B9C4C6793}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.Server.Tests", "tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj", "{FF3F77A7-CF65-4B57-8099-1D583FFE64B3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EchoHandler.Tests", "tests/EchoHandler.Tests/EchoHandler.Tests.csproj", "{8054CBD6-946B-4D55-BDC5-4E6F9049C5A6}"
@@ -31,6 +33,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActiveDirectoryServicePlugin.Tests", "tests/ActiveDirectoryServicePlugin.Tests/ActiveDirectoryServicePlugin.Tests.csproj", "{30C007D9-21C4-428B-875B-026888436985}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MsGraphServicePlugin.Tests", "tests/MsGraphServicePlugin.Tests/MsGraphServicePlugin.Tests.csproj", "{28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegistryServicePlugin.Tests", "tests/RegistryServicePlugin.Tests/RegistryServicePlugin.Tests.csproj", "{EA15A8F3-852D-467C-857A-A8FC85486457}"
 EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -98,6 +102,14 @@ Global
         {28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {28CF54EA-C802-4EB7-9C1C-EFE5695EA0A0}.Release|Any CPU.Build.0 = Release|Any CPU
+        {17CC2649-0CF3-451D-9BA2-F73B9C4C6793}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {17CC2649-0CF3-451D-9BA2-F73B9C4C6793}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {17CC2649-0CF3-451D-9BA2-F73B9C4C6793}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {17CC2649-0CF3-451D-9BA2-F73B9C4C6793}.Release|Any CPU.Build.0 = Release|Any CPU
+        {EA15A8F3-852D-467C-857A-A8FC85486457}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {EA15A8F3-852D-467C-857A-A8FC85486457}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {EA15A8F3-852D-467C-857A-A8FC85486457}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {EA15A8F3-852D-467C-857A-A8FC85486457}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/services/RegistryServicePlugin/RegistryService.cs
+++ b/plugins/services/RegistryServicePlugin/RegistryService.cs
@@ -1,0 +1,77 @@
+using System;
+using Microsoft.Win32;
+using TaskHub.Abstractions;
+
+namespace RegistryServicePlugin;
+
+public class RegistryServicePlugin : IServicePlugin
+{
+    public string Name => "registry";
+
+    public object GetService() => new RegistryService();
+
+    private class RegistryService
+    {
+        public ServiceResult Read(string keyPath, string property)
+        {
+            try
+            {
+                var (hive, subKey) = SplitHive(keyPath);
+                using var key = hive.OpenSubKey(subKey);
+                if (key == null)
+                {
+                    return new ServiceResult(null, $"Registry key '{keyPath}' not found");
+                }
+
+                var value = key.GetValue(property);
+                if (value == null)
+                {
+                    return new ServiceResult(null, $"Property '{property}' not found in '{keyPath}'");
+                }
+
+                return new ServiceResult(value, "success");
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult(null, $"Failed to read '{property}' from '{keyPath}': {ex.Message}");
+            }
+        }
+
+        public ServiceResult Write(string keyPath, string property, object value)
+        {
+            try
+            {
+                var (hive, subKey) = SplitHive(keyPath);
+                using var key = hive.CreateSubKey(subKey);
+                if (key == null)
+                {
+                    return new ServiceResult(null, $"Registry key '{keyPath}' could not be opened");
+                }
+
+                key.SetValue(property, value);
+                return new ServiceResult(value, "success");
+            }
+            catch (Exception ex)
+            {
+                return new ServiceResult(null, $"Failed to write '{property}' to '{keyPath}': {ex.Message}");
+            }
+        }
+
+        private static (RegistryKey hive, string subKey) SplitHive(string keyPath)
+        {
+            var parts = keyPath.Split(new[] {'\\'}, 2);
+            var hiveName = parts[0].ToUpperInvariant();
+            var subKey = parts.Length > 1 ? parts[1] : string.Empty;
+            RegistryKey hive = hiveName switch
+            {
+                "HKEY_CLASSES_ROOT" or "HKCR" => Registry.ClassesRoot,
+                "HKEY_CURRENT_USER" or "HKCU" => Registry.CurrentUser,
+                "HKEY_LOCAL_MACHINE" or "HKLM" => Registry.LocalMachine,
+                "HKEY_USERS" or "HKU" => Registry.Users,
+                "HKEY_CURRENT_CONFIG" or "HKCC" => Registry.CurrentConfig,
+                _ => throw new ArgumentException($"Unknown hive: {hiveName}", nameof(keyPath))
+            };
+            return (hive, subKey);
+        }
+    }
+}

--- a/plugins/services/RegistryServicePlugin/RegistryServicePlugin.csproj
+++ b/plugins/services/RegistryServicePlugin/RegistryServicePlugin.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/src/TaskHub.Abstractions/ServiceResult.cs
+++ b/src/TaskHub.Abstractions/ServiceResult.cs
@@ -1,0 +1,10 @@
+namespace TaskHub.Abstractions;
+
+/// <summary>
+/// Generic result object returned by services when performing operations.
+/// Contains either the resulting payload or an error message.
+/// </summary>
+/// <param name="Payload">Successful result payload if any.</param>
+/// <param name="Result">"success" or an error message describing the failure.</param>
+public record ServiceResult(object? Payload, string Result);
+

--- a/tests/RegistryServicePlugin.Tests/RegistryServicePlugin.Tests.csproj
+++ b/tests/RegistryServicePlugin.Tests/RegistryServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\RegistryServicePlugin\\RegistryServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/RegistryServicePlugin.Tests/RegistryServicePluginTests.cs
+++ b/tests/RegistryServicePlugin.Tests/RegistryServicePluginTests.cs
@@ -1,0 +1,34 @@
+using System;
+using RegistryServicePlugin;
+using TaskHub.Abstractions;
+using Xunit;
+
+namespace RegistryServicePlugin.Tests;
+
+public class RegistryServicePluginTests
+{
+    [Fact]
+    public void NameIsRegistry()
+    {
+        var plugin = new RegistryServicePlugin();
+        Assert.Equal("registry", plugin.Name);
+    }
+
+    [Fact]
+    public void ReadMissingKeyReturnsError()
+    {
+        dynamic service = new RegistryServicePlugin().GetService();
+        ServiceResult result = service.Read("HKEY_CURRENT_USER\\Software\\TaskHub_Missing", "Value");
+        Assert.Null(result.Payload);
+        Assert.Contains("Registry key", result.Result);
+    }
+
+    [Fact]
+    public void WriteWithNullPropertyReturnsError()
+    {
+        dynamic service = new RegistryServicePlugin().GetService();
+        ServiceResult result = service.Write("HKEY_CURRENT_USER\\Software\\TaskHub_Test", null!, "value");
+        Assert.Null(result.Payload);
+        Assert.Contains("Failed to write", result.Result);
+    }
+}


### PR DESCRIPTION
## Summary
- add a registry service plugin exposing read and write operations
- add tests for registry service plugin
- add error handling for registry read and write operations
- return result objects from registry operations instead of throwing
- introduce generic `ServiceResult` shared across services

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab246378608321a854fcd41edc111e