### PR TITLE
Generalize result object for services and handlers

### DIFF
--- a/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
@@ -15,10 +15,11 @@ public class CleanTempCommand : ICommand
 
     public CleanTempRequest Request { get; }
 
-    public Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
     {
         var cleaner = (Action<string>)service.GetService();
         cleaner(Request.Path);
-        return Task.FromResult(JsonSerializer.SerializeToElement(Request.Path));
+        var element = JsonSerializer.SerializeToElement(Request.Path);
+        return Task.FromResult(new OperationResult(element, "success"));
     }
 }

--- a/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
+++ b/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
@@ -15,14 +15,15 @@ public class DeleteFolderCommand : ICommand
 
     public DeleteFolderRequest Request { get; }
 
-    public Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
     {
         if (Directory.Exists(Request.Path))
         {
             Directory.Delete(Request.Path, true);
         }
 
-        return Task.FromResult(JsonSerializer.SerializeToElement(Request.Path));
+        var element = JsonSerializer.SerializeToElement(Request.Path);
+        return Task.FromResult(new OperationResult(element, "success"));
     }
 }
 

--- a/plugins/handlers/EchoHandler/EchoCommand.cs
+++ b/plugins/handlers/EchoHandler/EchoCommand.cs
@@ -16,12 +16,12 @@ public class EchoCommand : ICommand
 
     public EchoRequest Request { get; }
 
-    public async Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
     {
         var client = (HttpClient)service.GetService();
         var result = await client.GetStringAsync(Request.Resource, cancellationToken);
         Console.WriteLine($"Echo: {result}");
-        return JsonSerializer.SerializeToElement(result);
+        return new OperationResult(JsonSerializer.SerializeToElement(result), "success");
     }
 }
 

--- a/src/TaskHub.Abstractions/Interfaces/ICommand.cs
+++ b/src/TaskHub.Abstractions/Interfaces/ICommand.cs
@@ -1,11 +1,11 @@
 namespace TaskHub.Abstractions;
 
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Text.Json;
 
 public interface ICommand
 {
-    Task<JsonElement> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken);
+    Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken);
 }
 

--- a/src/TaskHub.Abstractions/OperationResult.cs
+++ b/src/TaskHub.Abstractions/OperationResult.cs
@@ -1,10 +1,12 @@
+using System.Text.Json;
+
 namespace TaskHub.Abstractions;
 
 /// <summary>
-/// Generic result object returned by services when performing operations.
+/// Generic result object returned by services and handlers when performing operations.
 /// Contains either the resulting payload or an error message.
 /// </summary>
 /// <param name="Payload">Successful result payload if any.</param>
 /// <param name="Result">"success" or an error message describing the failure.</param>
-public record ServiceResult(object? Payload, string Result);
+public record OperationResult(JsonElement? Payload, string Result);
 

--- a/tests/RegistryServicePlugin.Tests/RegistryServicePluginTests.cs
+++ b/tests/RegistryServicePlugin.Tests/RegistryServicePluginTests.cs
@@ -18,7 +18,7 @@ public class RegistryServicePluginTests
     public void ReadMissingKeyReturnsError()
     {
         dynamic service = new RegistryServicePlugin().GetService();
-        ServiceResult result = service.Read("HKEY_CURRENT_USER\\Software\\TaskHub_Missing", "Value");
+        OperationResult result = service.Read("HKEY_CURRENT_USER\\Software\\TaskHub_Missing", "Value");
         Assert.Null(result.Payload);
         Assert.Contains("Registry key", result.Result);
     }
@@ -27,7 +27,7 @@ public class RegistryServicePluginTests
     public void WriteWithNullPropertyReturnsError()
     {
         dynamic service = new RegistryServicePlugin().GetService();
-        ServiceResult result = service.Write("HKEY_CURRENT_USER\\Software\\TaskHub_Test", null!, "value");
+        OperationResult result = service.Write("HKEY_CURRENT_USER\\Software\\TaskHub_Test", null!, "value");
         Assert.Null(result.Payload);
         Assert.Contains("Failed to write", result.Result);
     }

--- a/tests/TaskHub.Server.Tests/PluginManagerTests.cs
+++ b/tests/TaskHub.Server.Tests/PluginManagerTests.cs
@@ -69,9 +69,10 @@ public class PluginManagerTests
 
     private class StubCommand : ICommand
     {
-        public System.Threading.Tasks.Task<System.Text.Json.JsonElement> ExecuteAsync(IServicePlugin service, System.Threading.CancellationToken cancellationToken)
+        public System.Threading.Tasks.Task<OperationResult> ExecuteAsync(IServicePlugin service, System.Threading.CancellationToken cancellationToken)
         {
-            return System.Threading.Tasks.Task.FromResult(System.Text.Json.JsonDocument.Parse("{}" ).RootElement);
+            var element = System.Text.Json.JsonDocument.Parse("{}" ).RootElement;
+            return System.Threading.Tasks.Task.FromResult(new OperationResult(element, "success"));
         }
     }
 


### PR DESCRIPTION
## Summary
- Introduce `OperationResult` record for shared service and handler responses
- Update command interface and implementations to return `OperationResult`
- Return `OperationResult` from `CommandExecutor` and plugin services/handlers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2c25aeb083219fd5e4fd85cac285