### PR TITLE
Add configurable WebSocket job handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Plugins must be compiled and copied under the `plugins` directory as described i
 The `TaskHub.Abstractions` project contains shared interfaces and result types and can be packaged as a NuGet
 dependency for plugin development.
 
+### Job handling modes
+
+The server handles job submissions through the HTTP API by default. Set `JobHandling:Mode` in
+`appsettings.json` to `WebSocket` and provide `JobHandling:WebSocketServerUrl` to receive jobs from a remote
+server over a WebSocket connection instead.
+
 ## ESLint
 
 For JavaScript or TypeScript plugins, run ESLint to ensure code quality:

--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -17,6 +17,12 @@ builder.Services.AddSingleton<PluginManager>();
 builder.Services.AddSingleton<CommandExecutor>();
 builder.Services.AddOpenApiDocument();
 
+var jobHandlingMode = builder.Configuration.GetValue<string>("JobHandling:Mode");
+if (string.Equals(jobHandlingMode, "WebSocket", StringComparison.OrdinalIgnoreCase))
+{
+    builder.Services.AddHostedService<WebSocketJobService>();
+}
+
 var app = builder.Build();
 
 app.UseOpenApi();
@@ -31,7 +37,11 @@ var pluginManager = app.Services.GetRequiredService<PluginManager>();
 pluginManager.Load(Path.Combine(AppContext.BaseDirectory, "plugins"));
 
 app.MapPluginEndpoints();
-app.MapCommandEndpoints();
+
+if (!string.Equals(jobHandlingMode, "WebSocket", StringComparison.OrdinalIgnoreCase))
+{
+    app.MapCommandEndpoints();
+}
 
 app.Run();
 

--- a/src/TaskHub.Server/WebSocketJobService.cs
+++ b/src/TaskHub.Server/WebSocketJobService.cs
@@ -1,0 +1,92 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Hangfire;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace TaskHub.Server;
+
+public class WebSocketJobService : BackgroundService
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<WebSocketJobService> _logger;
+    private readonly IBackgroundJobClient _client;
+
+    public WebSocketJobService(IConfiguration configuration, ILogger<WebSocketJobService> logger, IBackgroundJobClient client)
+    {
+        _configuration = configuration;
+        _logger = logger;
+        _client = client;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var url = _configuration["JobHandling:WebSocketServerUrl"];
+        if (string.IsNullOrEmpty(url))
+        {
+            _logger.LogWarning("WebSocket server URL is not configured.");
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            using var socket = new ClientWebSocket();
+            try
+            {
+                await socket.ConnectAsync(new Uri(url), stoppingToken);
+                await ReceiveLoop(socket, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "WebSocket connection failed.");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+    }
+
+    private async Task ReceiveLoop(ClientWebSocket socket, CancellationToken token)
+    {
+        var buffer = new byte[8192];
+        var builder = new StringBuilder();
+
+        while (socket.State == WebSocketState.Open && !token.IsCancellationRequested)
+        {
+            var result = await socket.ReceiveAsync(buffer, token);
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "closing", token);
+                break;
+            }
+
+            builder.Append(Encoding.UTF8.GetString(buffer, 0, result.Count));
+
+            if (result.EndOfMessage)
+            {
+                var message = builder.ToString();
+                builder.Clear();
+
+                try
+                {
+                    var request = JsonSerializer.Deserialize<CommandChainRequest>(message);
+                    if (request != null)
+                    {
+                        _client.Enqueue<CommandExecutor>(exec => exec.ExecuteChain(request.Commands, request.Payload, null!, CancellationToken.None));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to process job message {Message}", message);
+                }
+            }
+        }
+    }
+}
+

--- a/src/TaskHub.Server/appsettings.json
+++ b/src/TaskHub.Server/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "JobHandling": {
+    "Mode": "Api",
+    "WebSocketServerUrl": "ws://localhost:8080/ws"
+  },
   "PluginSettings": {
     "MsGraph": {
       "TenantId": "your-tenant-id",


### PR DESCRIPTION
## Summary
- allow choosing job intake via HTTP API or WebSocket client using `JobHandling` settings
- implement `WebSocketJobService` for receiving jobs from a WebSocket server
- document new job handling modes in README

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab37cc72208321bc5def4f9a284a45