### PR TITLE
Pass WebSocket connection to handlers

### DIFF
--- a/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.WebSockets;
 using TaskHub.Abstractions;
 
 namespace CleanTempHandler;
@@ -15,7 +16,7 @@ public class CleanTempCommand : ICommand
 
     public CleanTempRequest Request { get; }
 
-    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken, ClientWebSocket? socket = null)
     {
         var cleaner = (Action<string>)service.GetService();
         cleaner(Request.Path);

--- a/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
+++ b/plugins/handlers/CleanTempHandler/DeleteFolderCommand.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.WebSockets;
 using TaskHub.Abstractions;
 
 namespace CleanTempHandler;
@@ -15,7 +16,7 @@ public class DeleteFolderCommand : ICommand
 
     public DeleteFolderRequest Request { get; }
 
-    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken, ClientWebSocket? socket = null)
     {
         if (Directory.Exists(Request.Path))
         {

--- a/plugins/handlers/EchoHandler/EchoCommand.cs
+++ b/plugins/handlers/EchoHandler/EchoCommand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Net.WebSockets;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +17,7 @@ public class EchoCommand : ICommand
 
     public EchoRequest Request { get; }
 
-    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken, ClientWebSocket? socket = null)
     {
         var client = (HttpClient)service.GetService();
         var result = await client.GetStringAsync(Request.Resource, cancellationToken);

--- a/src/TaskHub.Abstractions/Interfaces/ICommand.cs
+++ b/src/TaskHub.Abstractions/Interfaces/ICommand.cs
@@ -1,11 +1,15 @@
 namespace TaskHub.Abstractions;
 
+using System.Net.WebSockets;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
 public interface ICommand
 {
-    Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken);
+    Task<OperationResult> ExecuteAsync(
+        IServicePlugin service,
+        CancellationToken cancellationToken,
+        ClientWebSocket? socket = null);
 }
 

--- a/src/TaskHub.Server/WebSocketJobService.cs
+++ b/src/TaskHub.Server/WebSocketJobService.cs
@@ -78,7 +78,7 @@ public class WebSocketJobService : BackgroundService
                     var request = JsonSerializer.Deserialize<CommandChainRequest>(message);
                     if (request != null)
                     {
-                        _client.Enqueue<CommandExecutor>(exec => exec.ExecuteChain(request.Commands, request.Payload, null!, CancellationToken.None));
+                        _client.Enqueue<CommandExecutor>(exec => exec.ExecuteChain(request.Commands, request.Payload, null!, CancellationToken.None, socket));
                     }
                 }
                 catch (Exception ex)

--- a/tests/TaskHub.Server.Tests/PluginManagerTests.cs
+++ b/tests/TaskHub.Server.Tests/PluginManagerTests.cs
@@ -69,7 +69,10 @@ public class PluginManagerTests
 
     private class StubCommand : ICommand
     {
-        public System.Threading.Tasks.Task<OperationResult> ExecuteAsync(IServicePlugin service, System.Threading.CancellationToken cancellationToken)
+        public System.Threading.Tasks.Task<OperationResult> ExecuteAsync(
+            IServicePlugin service,
+            System.Threading.CancellationToken cancellationToken,
+            System.Net.WebSockets.ClientWebSocket? socket = null)
         {
             var element = System.Text.Json.JsonDocument.Parse("{}" ).RootElement;
             return System.Threading.Tasks.Task.FromResult(new OperationResult(element, "success"));


### PR DESCRIPTION
## Summary
- Allow commands to receive an optional `ClientWebSocket` connection
- Pass WebSocket connection through `CommandExecutor` and `WebSocketJobService`
- Update sample handlers and tests for new optional socket parameter

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3b9f766483218d2782b703c59331