### PR TITLE
Add WebSocket server with command dispatch endpoint

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.Abstractions", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.Server", "src/TaskHub.Server/TaskHub.Server.csproj", "{20BE2950-701D-4DFF-97A7-8DA41CB75EFE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.WebSocketServer", "src/TaskHub.WebSocketServer/TaskHub.WebSocketServer.csproj", "{70293912-7C1C-4A0D-AD9A-B300E9186B20}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EchoHandler", "plugins/handlers/EchoHandler/EchoHandler.csproj", "{AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpServicePlugin", "plugins/services/HttpServicePlugin/HttpServicePlugin.csproj", "{DB07147A-1AC2-4E01-9C32-82300A5243EB}"
@@ -50,6 +52,10 @@ Global
         {20BE2950-701D-4DFF-97A7-8DA41CB75EFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {20BE2950-701D-4DFF-97A7-8DA41CB75EFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {20BE2950-701D-4DFF-97A7-8DA41CB75EFE}.Release|Any CPU.Build.0 = Release|Any CPU
+        {70293912-7C1C-4A0D-AD9A-B300E9186B20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {70293912-7C1C-4A0D-AD9A-B300E9186B20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {70293912-7C1C-4A0D-AD9A-B300E9186B20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {70293912-7C1C-4A0D-AD9A-B300E9186B20}.Release|Any CPU.Build.0 = Release|Any CPU
         {AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
         {AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {AFE3A644-3564-4B7A-9BFD-8AD4BFFDE6E5}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/TaskHub.WebSocketServer/Program.cs
+++ b/src/TaskHub.WebSocketServer/Program.cs
@@ -1,0 +1,57 @@
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+var sockets = new ConcurrentDictionary<WebSocket, byte>();
+
+app.UseWebSockets();
+
+app.MapGet("/", () => "WebSocket server running");
+
+app.Map("/ws", async context =>
+{
+    if (!context.WebSockets.IsWebSocketRequest)
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        return;
+    }
+
+    using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+    sockets.TryAdd(webSocket, 0);
+
+    var buffer = new byte[1024 * 4];
+    var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+    while (!result.CloseStatus.HasValue)
+    {
+        await webSocket.SendAsync(new ArraySegment<byte>(buffer, 0, result.Count), result.MessageType, result.EndOfMessage, CancellationToken.None);
+        result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+    }
+
+    sockets.TryRemove(webSocket, out _);
+    await webSocket.CloseAsync(result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None);
+});
+
+app.MapPost("/command", async (JsonElement request) =>
+{
+    if (!request.TryGetProperty("command", out var commandEl))
+    {
+        return Results.BadRequest();
+    }
+
+    var message = Encoding.UTF8.GetBytes(commandEl.GetRawText());
+    foreach (var socket in sockets.Keys)
+    {
+        if (socket.State == WebSocketState.Open)
+        {
+            await socket.SendAsync(new ArraySegment<byte>(message), WebSocketMessageType.Text, true, CancellationToken.None);
+        }
+    }
+
+    return Results.Ok();
+});
+
+app.Run();

--- a/src/TaskHub.WebSocketServer/TaskHub.WebSocketServer.csproj
+++ b/src/TaskHub.WebSocketServer/TaskHub.WebSocketServer.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- track connected WebSocket clients so commands can be pushed to them
- add `/command` endpoint to broadcast command requests to open sockets
- parse command JSON with `System.Text.Json` before broadcasting

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab74ac12b08321aa6500c0d2188704