### PR TITLE
Document TaskHub architecture in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,41 @@
 
 Sample Hangfire-based server with plugin-based command handlers and service plugins.
 
+## Architecture Overview
+
+TaskHub boots an ASP.NET minimal app with Hangfire for background job scheduling, registering services such as `PluginManager`, `CommandExecutor`, and `PayloadVerifier`, then loads plugin assemblies from the `plugins` directory and maps both plugin and command endpoints.
+
+The `/commands` API verifies an optional payload signature, enqueues or schedules command chains, cancels jobs, and returns status with executed-command history.
+
+`PluginManager` scans the plugin folders for service and handler assemblies, instantiates them via dependency injection, and tracks loaded DLLs for later retrieval.
+
+`CommandExecutor` resolves each command’s handler and required service plugin, executes the chain sequentially, and records results per job for status queries.
+
+Payload signatures are optionally validated against an X509 certificate to ensure integrity.
+
+When configured for WebSocket mode, a background service connects to a remote WebSocket server, receives serialized command requests, verifies them, and enqueues jobs via Hangfire; the companion WebSocket server maintains client connections at `/ws` and relays commands received through `/command` to matching clients.
+
+The extension points rely on shared abstractions: `ICommand` executes against a service, `ICommandHandler` maps command names to service plugins, and `IServicePlugin` exposes a service instance.
+
+An example `EchoCommandHandler` routes the “echo” command to the `HttpServicePlugin`, whose command implementation uses an injected `HttpClient` to fetch resources.
+
+The system also exposes `/dlls` to list the plugin assemblies currently loaded, aiding visibility into active extensions.
+
+### Architecture Diagram
+
+```mermaid
+flowchart LR
+    client[Client] -->|HTTP /commands| api[TaskHub Server]
+    client -->|WebSocket| ws[WebSocket Server]
+    ws --> api
+    api --> verifier[PayloadVerifier]
+    api --> hangfire[Hangfire Scheduler]
+    hangfire --> executor[CommandExecutor]
+    executor --> manager[PluginManager]
+    manager --> handlers[CommandHandlers]
+    handlers --> services[Service Plugins]
+```
+
 ## Building
 
 Requires the .NET 8 SDK.


### PR DESCRIPTION
## Summary
- expand README with an Architecture Overview describing core services, APIs, and plugin flow
- add a mermaid diagram visualizing TaskHub's components and communication paths

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac04c03ec08321a4e75f7a52bd9f44