### PR TITLE
Add Configuration Manager admin service plugin

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegistryServicePlugin", "pl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerServicePlugin", "plugins/services/ConfigurationManagerServicePlugin/ConfigurationManagerServicePlugin.csproj", "{33C374C4-43A3-49FD-93B2-21485F2381CD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerAdminServicePlugin", "plugins/services/ConfigurationManagerAdminServicePlugin/ConfigurationManagerAdminServicePlugin.csproj", "{D116BFAD-093B-4BD6-9F9F-07C9383776A9}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskHub.Server.Tests", "tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj", "{FF3F77A7-CF65-4B57-8099-1D583FFE64B3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EchoHandler.Tests", "tests/EchoHandler.Tests/EchoHandler.Tests.csproj", "{8054CBD6-946B-4D55-BDC5-4E6F9049C5A6}"
@@ -41,6 +43,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RegistryServicePlugin.Tests", "tests/RegistryServicePlugin.Tests/RegistryServicePlugin.Tests.csproj", "{EA15A8F3-852D-467C-857A-A8FC85486457}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerServicePlugin.Tests", "tests/ConfigurationManagerServicePlugin.Tests/ConfigurationManagerServicePlugin.Tests.csproj", "{6D397CB3-9F07-4646-A850-D54214A54B3E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerAdminServicePlugin.Tests", "tests/ConfigurationManagerAdminServicePlugin.Tests/ConfigurationManagerAdminServicePlugin.Tests.csproj", "{141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}"
 EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -124,10 +128,18 @@ Global
         {33C374C4-43A3-49FD-93B2-21485F2381CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {33C374C4-43A3-49FD-93B2-21485F2381CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {33C374C4-43A3-49FD-93B2-21485F2381CD}.Release|Any CPU.Build.0 = Release|Any CPU
+        {D116BFAD-093B-4BD6-9F9F-07C9383776A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {D116BFAD-093B-4BD6-9F9F-07C9383776A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {D116BFAD-093B-4BD6-9F9F-07C9383776A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {D116BFAD-093B-4BD6-9F9F-07C9383776A9}.Release|Any CPU.Build.0 = Release|Any CPU
         {6D397CB3-9F07-4646-A850-D54214A54B3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
         {6D397CB3-9F07-4646-A850-D54214A54B3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {6D397CB3-9F07-4646-A850-D54214A54B3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {6D397CB3-9F07-4646-A850-D54214A54B3E}.Release|Any CPU.Build.0 = Release|Any CPU
+        {141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/services/ConfigurationManagerAdminServicePlugin/ConfigurationManagerAdminService.cs
+++ b/plugins/services/ConfigurationManagerAdminServicePlugin/ConfigurationManagerAdminService.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace ConfigurationManagerAdminServicePlugin;
+
+public class ConfigurationManagerAdminServicePlugin : IServicePlugin
+{
+    public string Name => "configurationmanageradmin";
+
+    public object GetService() => new ConfigurationManagerAdminService();
+
+    private class ConfigurationManagerAdminService
+    {
+        private readonly HttpClient _client;
+
+        public ConfigurationManagerAdminService()
+        {
+            _client = new HttpClient(new HttpClientHandler
+            {
+                UseDefaultCredentials = true
+            });
+        }
+
+        public async Task<OperationResult> Get(string baseUrl, string resource, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var url = $"{baseUrl.TrimEnd('/')}/{resource.TrimStart('/')}";
+                var response = await _client.GetAsync(url, cancellationToken);
+                var json = await response.Content.ReadAsStringAsync(cancellationToken);
+                var element = JsonSerializer.Deserialize<JsonElement>(json);
+                return new OperationResult(element, "success");
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult(null, $"Failed to query admin service '{resource}': {ex.Message}");
+            }
+        }
+    }
+}

--- a/plugins/services/ConfigurationManagerAdminServicePlugin/ConfigurationManagerAdminServicePlugin.csproj
+++ b/plugins/services/ConfigurationManagerAdminServicePlugin/ConfigurationManagerAdminServicePlugin.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/tests/ConfigurationManagerAdminServicePlugin.Tests/ConfigurationManagerAdminServicePlugin.Tests.csproj
+++ b/tests/ConfigurationManagerAdminServicePlugin.Tests/ConfigurationManagerAdminServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\ConfigurationManagerAdminServicePlugin\\ConfigurationManagerAdminServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/ConfigurationManagerAdminServicePlugin.Tests/ConfigurationManagerAdminServicePluginTests.cs
+++ b/tests/ConfigurationManagerAdminServicePlugin.Tests/ConfigurationManagerAdminServicePluginTests.cs
@@ -1,0 +1,14 @@
+using ConfigurationManagerAdminServicePlugin;
+using Xunit;
+
+namespace ConfigurationManagerAdminServicePlugin.Tests;
+
+public class ConfigurationManagerAdminServicePluginTests
+{
+    [Fact]
+    public void NameIsConfigurationManagerAdmin()
+    {
+        var plugin = new ConfigurationManagerAdminServicePlugin();
+        Assert.Equal("configurationmanageradmin", plugin.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ConfigurationManagerAdminServicePlugin` to query Configuration Manager's Admin Service via HTTP with default credentials
- add unit tests asserting the plugin name
- register the new plugin and its tests in the solution file

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac952374a8832181243db91cb91961