### PR TITLE
Add read, write and delete service operations

### DIFF
--- a/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommand.cs
@@ -18,8 +18,8 @@ public class CleanTempCommand : ICommand
 
     public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken, ClientWebSocket? socket = null)
     {
-        var cleaner = (Action<string>)service.GetService();
-        cleaner(Request.Path);
+        dynamic fs = service.GetService();
+        fs.Delete(Request.Path);
         var element = JsonSerializer.SerializeToElement(Request.Path);
         return Task.FromResult(new OperationResult(element, "success"));
     }

--- a/plugins/services/RegistryServicePlugin/RegistryService.cs
+++ b/plugins/services/RegistryServicePlugin/RegistryService.cs
@@ -60,6 +60,26 @@ public class RegistryServicePlugin : IServicePlugin
             }
         }
 
+        public OperationResult Delete(string keyPath, string property)
+        {
+            try
+            {
+                var (hive, subKey) = SplitHive(keyPath);
+                using var key = hive.OpenSubKey(subKey, writable: true);
+                if (key == null)
+                {
+                    return new OperationResult(null, $"Registry key '{keyPath}' not found");
+                }
+
+                key.DeleteValue(property, false);
+                return new OperationResult(null, "success");
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult(null, $"Failed to delete '{property}' from '{keyPath}': {ex.Message}");
+            }
+        }
+
         private static (RegistryKey hive, string subKey) SplitHive(string keyPath)
         {
             var parts = keyPath.Split(new[] {'\\'}, 2);

--- a/tests/FileSystemServicePlugin.Tests/FileSystemServicePluginTests.cs
+++ b/tests/FileSystemServicePlugin.Tests/FileSystemServicePluginTests.cs
@@ -1,4 +1,6 @@
 using FileSystemServicePlugin;
+using System.IO;
+using TaskHub.Abstractions;
 using Xunit;
 
 namespace FileSystemServicePlugin.Tests;
@@ -10,5 +12,23 @@ public class FileSystemServicePluginTests
     {
         var plugin = new FileSystemServicePlugin();
         Assert.Equal("filesystem", plugin.Name);
+    }
+
+    [Fact]
+    public void CanReadWriteAndDeleteFile()
+    {
+        var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        dynamic service = new FileSystemServicePlugin().GetService();
+
+        OperationResult write = service.Write(tempFile, "hello");
+        Assert.Equal("success", write.Result);
+        Assert.True(File.Exists(tempFile));
+
+        OperationResult read = service.Read(tempFile);
+        Assert.Equal("hello", read.Payload?.GetString());
+
+        OperationResult delete = service.Delete(tempFile);
+        Assert.Equal("success", delete.Result);
+        Assert.False(File.Exists(tempFile));
     }
 }

--- a/tests/RegistryServicePlugin.Tests/RegistryServicePluginTests.cs
+++ b/tests/RegistryServicePlugin.Tests/RegistryServicePluginTests.cs
@@ -31,4 +31,13 @@ public class RegistryServicePluginTests
         Assert.Null(result.Payload);
         Assert.Contains("Failed to write", result.Result);
     }
+
+    [Fact]
+    public void DeleteMissingKeyReturnsError()
+    {
+        dynamic service = new RegistryServicePlugin().GetService();
+        OperationResult result = service.Delete("HKEY_CURRENT_USER\\Software\\TaskHub_Missing", "Value");
+        Assert.Null(result.Payload);
+        Assert.Contains("Failed to delete", result.Result);
+    }
 }


### PR DESCRIPTION
## Summary
- Extend file system service plugin with read, write and delete operations
- Provide delete capability for registry service
- Update CleanTemp command and tests for new service methods

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac97600c688321b12d9a6c4b87c18a