### PR TITLE
Add restricted path failsafe to FileSystemService

### DIFF
--- a/tests/FileSystemServicePlugin.Tests/FileSystemServicePluginTests.cs
+++ b/tests/FileSystemServicePlugin.Tests/FileSystemServicePluginTests.cs
@@ -1,4 +1,5 @@
 using FileSystemServicePlugin;
+using System;
 using System.IO;
 using TaskHub.Abstractions;
 using Xunit;
@@ -30,5 +31,15 @@ public class FileSystemServicePluginTests
         OperationResult delete = service.Delete(tempFile);
         Assert.Equal("success", delete.Result);
         Assert.False(File.Exists(tempFile));
+    }
+
+    [Fact]
+    public void RestrictedPathsThrow()
+    {
+        dynamic service = new FileSystemServicePlugin().GetService();
+
+        Assert.Throws<InvalidOperationException>(() => service.Read("/etc/passwd"));
+        Assert.Throws<InvalidOperationException>(() => service.Write("/etc/passwd", "test"));
+        Assert.Throws<InvalidOperationException>(() => service.Delete("/etc/passwd"));
     }
 }


### PR DESCRIPTION
## Summary
- block access to system directories in FileSystemService and throw an exception for restricted paths
- add unit tests verifying disallowed paths throw InvalidOperationException

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b3be69c8321a486f6b3fec5dfa7