### PR TITLE
Add PowerShell script execution service

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -46,12 +46,24 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerService
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerAdminServicePlugin.Tests", "tests/ConfigurationManagerAdminServicePlugin.Tests/ConfigurationManagerAdminServicePlugin.Tests.csproj", "{141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerShellServicePlugin", "plugins/services/PowerShellServicePlugin/PowerShellServicePlugin.csproj", "{16EBB5CC-B994-4D4A-8739-3E9A7F23E4F0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerShellServicePlugin.Tests", "tests/PowerShellServicePlugin.Tests/PowerShellServicePlugin.Tests.csproj", "{3E80944E-F7E3-49B4-92B8-EBE4DD7496FF}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
         Release|Any CPU = Release|Any CPU
     EndGlobalSection
     GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {16EBB5CC-B994-4D4A-8739-3E9A7F23E4F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {16EBB5CC-B994-4D4A-8739-3E9A7F23E4F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {16EBB5CC-B994-4D4A-8739-3E9A7F23E4F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {16EBB5CC-B994-4D4A-8739-3E9A7F23E4F0}.Release|Any CPU.Build.0 = Release|Any CPU
+        {3E80944E-F7E3-49B4-92B8-EBE4DD7496FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3E80944E-F7E3-49B4-92B8-EBE4DD7496FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3E80944E-F7E3-49B4-92B8-EBE4DD7496FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3E80944E-F7E3-49B4-92B8-EBE4DD7496FF}.Release|Any CPU.Build.0 = Release|Any CPU
         {66A1BBE9-8CEA-4EF6-A168-94DF8EA8CFDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
         {66A1BBE9-8CEA-4EF6-A168-94DF8EA8CFDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {66A1BBE9-8CEA-4EF6-A168-94DF8EA8CFDF}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/plugins/services/PowerShellServicePlugin/PowerShellService.cs
+++ b/plugins/services/PowerShellServicePlugin/PowerShellService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using TaskHub.Abstractions;
+
+namespace PowerShellServicePlugin;
+
+public class PowerShellServicePlugin : IServicePlugin
+{
+    public string Name => "powershell";
+
+    public object GetService() => new PowerShellService();
+
+    private class PowerShellService
+    {
+        public OperationResult Execute(string scriptBase64, string? version = null, Dictionary<string, object>? properties = null)
+        {
+            try
+            {
+                var script = Encoding.UTF8.GetString(Convert.FromBase64String(scriptBase64));
+                var initial = InitialSessionState.CreateDefault();
+
+                if (properties != null)
+                {
+                    foreach (var kvp in properties)
+                    {
+                        initial.Variables.Add(new SessionStateVariableEntry(kvp.Key, kvp.Value, string.Empty));
+                    }
+                }
+
+                using var ps = System.Management.Automation.PowerShell.Create(initial);
+
+                if (!string.IsNullOrEmpty(version))
+                {
+                    var engineVersion = ps.Runspace.Version.ToString();
+                    if (!engineVersion.StartsWith(version, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new OperationResult(null, $"Requested PowerShell version {version} is not available (engine is {engineVersion})");
+                    }
+                }
+
+                ps.AddScript(script);
+                var results = ps.Invoke();
+
+                if (ps.HadErrors)
+                {
+                    var error = string.Join("; ", ps.Streams.Error.Select(e => e.ToString()));
+                    return new OperationResult(null, error);
+                }
+
+                var output = new List<object?>();
+                foreach (var item in results)
+                {
+                    output.Add(item?.BaseObject);
+                }
+                var element = JsonSerializer.SerializeToElement(output);
+                return new OperationResult(element, "success");
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult(null, $"Failed to execute script: {ex.Message}");
+            }
+        }
+    }
+}
+

--- a/plugins/services/PowerShellServicePlugin/PowerShellServicePlugin.csproj
+++ b/plugins/services/PowerShellServicePlugin/PowerShellServicePlugin.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/tests/PowerShellServicePlugin.Tests/PowerShellServicePlugin.Tests.csproj
+++ b/tests/PowerShellServicePlugin.Tests/PowerShellServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\PowerShellServicePlugin\\PowerShellServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/PowerShellServicePlugin.Tests/PowerShellServicePluginTests.cs
+++ b/tests/PowerShellServicePlugin.Tests/PowerShellServicePluginTests.cs
@@ -1,0 +1,43 @@
+using PowerShellServicePlugin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Management.Automation;
+using TaskHub.Abstractions;
+using Xunit;
+
+namespace PowerShellServicePlugin.Tests;
+
+public class PowerShellServicePluginTests
+{
+    [Fact]
+    public void NameIsPowerShell()
+    {
+        var plugin = new PowerShellServicePlugin();
+        Assert.Equal("powershell", plugin.Name);
+    }
+
+    [Fact]
+    public void ExecutesScriptAndRespectsProperties()
+    {
+        dynamic service = new PowerShellServicePlugin().GetService();
+
+        string engineVersion;
+        using (var ps = PowerShell.Create())
+        {
+            engineVersion = ps.Runspace.Version.ToString();
+        }
+
+        var props = new Dictionary<string, object> { ["greeting"] = "Hello" };
+        var script = "Write-Output $greeting";
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(script));
+
+        OperationResult result = service.Execute(base64, engineVersion, props);
+        Assert.Equal("success", result.Result);
+        var element = result.Payload!.Value;
+        var first = element.EnumerateArray().First();
+        Assert.Equal("Hello", first.GetString());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add PowerShellServicePlugin to execute base64-encoded scripts with optional version and runspace properties
- include tests verifying script execution and variable handling
- register new service and tests in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9cb414d08321a2d24b82aedbbb3b