### PR TITLE
Add BitLocker service plugin

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -50,6 +50,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerShellServicePlugin", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerShellServicePlugin.Tests", "tests/PowerShellServicePlugin.Tests/PowerShellServicePlugin.Tests.csproj", "{3E80944E-F7E3-49B4-92B8-EBE4DD7496FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitLockerServicePlugin", "plugins/services/BitLockerServicePlugin/BitLockerServicePlugin.csproj", "{B3E8A1C2-0D5E-4C11-92F4-99F7A7EAD4A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitLockerServicePlugin.Tests", "tests/BitLockerServicePlugin.Tests/BitLockerServicePlugin.Tests.csproj", "{0F613CD3-5F28-4EF2-8E5D-DAE3B13087C5}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -152,6 +156,14 @@ Global
         {141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {141CEA8D-5CC4-4D0A-B4AC-A05BF6AD9637}.Release|Any CPU.Build.0 = Release|Any CPU
+        {B3E8A1C2-0D5E-4C11-92F4-99F7A7EAD4A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B3E8A1C2-0D5E-4C11-92F4-99F7A7EAD4A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B3E8A1C2-0D5E-4C11-92F4-99F7A7EAD4A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {B3E8A1C2-0D5E-4C11-92F4-99F7A7EAD4A1}.Release|Any CPU.Build.0 = Release|Any CPU
+        {0F613CD3-5F28-4EF2-8E5D-DAE3B13087C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {0F613CD3-5F28-4EF2-8E5D-DAE3B13087C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {0F613CD3-5F28-4EF2-8E5D-DAE3B13087C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {0F613CD3-5F28-4EF2-8E5D-DAE3B13087C5}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/services/BitLockerServicePlugin/BitLockerService.cs
+++ b/plugins/services/BitLockerServicePlugin/BitLockerService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Management;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace BitLockerServicePlugin;
+
+public class BitLockerService
+{
+    private readonly ILogger<BitLockerService> _logger;
+    private ManagementEventWatcher? _watcher;
+
+    public event Action<string, string>? KeyAvailable;
+
+    public BitLockerService(ILogger<BitLockerService> logger)
+    {
+        _logger = logger;
+        if (!OperatingSystem.IsWindows())
+        {
+            _logger.LogInformation("BitLocker service is only available on Windows.");
+            return;
+        }
+
+        _ = Task.Run(WatchAsync);
+    }
+
+    private async Task WatchAsync()
+    {
+        try
+        {
+            var query = new WqlEventQuery(
+                "__InstanceModificationEvent",
+                TimeSpan.FromSeconds(1),
+                "TargetInstance ISA 'Win32_EncryptableVolume' AND TargetInstance.LockStatus = 0");
+            _watcher = new ManagementEventWatcher(query);
+            _watcher.EventArrived += (_, e) =>
+            {
+                try
+                {
+                    var volume = (ManagementBaseObject)e.NewEvent["TargetInstance"];
+                    var deviceId = (string)volume["DeviceID"];
+                    using var vol = new ManagementObject($"Win32_EncryptableVolume.DeviceID='{deviceId}'");
+                    if (vol.InvokeMethod("GetKeyProtectors", new object[] { 0, null }) is ManagementBaseObject ids &&
+                        ids["VolumeKeyProtectorID"] is string[] protectorIds && protectorIds.Length > 0)
+                    {
+                        foreach (var id in protectorIds)
+                        {
+                            if (vol.InvokeMethod("GetKeyProtectorNumericalPassword", new object[] { id, null }) is ManagementBaseObject pw &&
+                                pw["NumericalPassword"] is string key)
+                            {
+                                KeyAvailable?.Invoke(deviceId, key);
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to process BitLocker event");
+                }
+            };
+            _watcher.Start();
+            await Task.Delay(Timeout.Infinite);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start BitLocker watcher");
+        }
+    }
+}
+

--- a/plugins/services/BitLockerServicePlugin/BitLockerServicePlugin.cs
+++ b/plugins/services/BitLockerServicePlugin/BitLockerServicePlugin.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+
+namespace BitLockerServicePlugin;
+
+public class BitLockerServicePlugin : IServicePlugin
+{
+    private readonly BitLockerService _service;
+
+    public BitLockerServicePlugin(ILogger<BitLockerService> logger)
+    {
+        _service = new BitLockerService(logger);
+    }
+
+    public string Name => "bitlocker";
+
+    public object GetService() => _service;
+}
+

--- a/plugins/services/BitLockerServicePlugin/BitLockerServicePlugin.csproj
+++ b/plugins/services/BitLockerServicePlugin/BitLockerServicePlugin.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/tests/BitLockerServicePlugin.Tests/BitLockerServicePlugin.Tests.csproj
+++ b/tests/BitLockerServicePlugin.Tests/BitLockerServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\BitLockerServicePlugin\\BitLockerServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/BitLockerServicePlugin.Tests/BitLockerServicePluginTests.cs
+++ b/tests/BitLockerServicePlugin.Tests/BitLockerServicePluginTests.cs
@@ -1,0 +1,22 @@
+using BitLockerServicePlugin;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BitLockerServicePlugin.Tests;
+
+public class BitLockerServicePluginTests
+{
+    [Fact]
+    public void NameIsBitLocker()
+    {
+        var plugin = new BitLockerServicePlugin(NullLogger<BitLockerService>.Instance);
+        Assert.Equal("bitlocker", plugin.Name);
+    }
+
+    [Fact]
+    public void ServiceIsExposed()
+    {
+        var plugin = new BitLockerServicePlugin(NullLogger<BitLockerService>.Instance);
+        Assert.IsType<BitLockerService>(plugin.GetService());
+    }
+}


### PR DESCRIPTION
## Summary
- expose BitLocker service that raises key-available events on Windows
- provide plugin wrapper without SignalR dependency and add tests

## Testing
- `dotnet --version` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9f545e388321a8d9c028dfe09279