### PR TITLE
Add Configuration Manager client handler

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -58,6 +58,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitLockerHandler", "plugins
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitLockerHandler.Tests", "tests/BitLockerHandler.Tests/BitLockerHandler.Tests.csproj", "{1B90C6E5-12F3-4E15-82DB-71DCE4AD42E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CcmExecHandler", "plugins/handlers/CcmExecHandler/CcmExecHandler.csproj", "{0781C5D5-3C75-4A13-A60D-241E7F9FA55D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CcmExecHandler.Tests", "tests/CcmExecHandler.Tests/CcmExecHandler.Tests.csproj", "{928FF438-504D-481F-897B-CB89160B12C8}"
+EndProject
+
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -176,6 +181,14 @@ Global
         {1B90C6E5-12F3-4E15-82DB-71DCE4AD42E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {1B90C6E5-12F3-4E15-82DB-71DCE4AD42E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {1B90C6E5-12F3-4E15-82DB-71DCE4AD42E2}.Release|Any CPU.Build.0 = Release|Any CPU
+        {0781C5D5-3C75-4A13-A60D-241E7F9FA55D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {0781C5D5-3C75-4A13-A60D-241E7F9FA55D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {0781C5D5-3C75-4A13-A60D-241E7F9FA55D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {0781C5D5-3C75-4A13-A60D-241E7F9FA55D}.Release|Any CPU.Build.0 = Release|Any CPU
+        {928FF438-504D-481F-897B-CB89160B12C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {928FF438-504D-481F-897B-CB89160B12C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {928FF438-504D-481F-897B-CB89160B12C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {928FF438-504D-481F-897B-CB89160B12C8}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/CcmExecHandler/CcmExecCommandHandler.cs
+++ b/plugins/handlers/CcmExecHandler/CcmExecCommandHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace CcmExecHandler;
+
+public class CcmExecCommandHandler : ICommandHandler<TriggerScheduleCommand>
+{
+    public IReadOnlyCollection<string> Commands => new[] { "ccmexwc" };
+    public string ServiceName => "configurationmanager";
+
+    public TriggerScheduleCommand Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<TriggerScheduleRequest>(payload.GetRawText())
+                      ?? new TriggerScheduleRequest();
+        return new TriggerScheduleCommand(request);
+    }
+
+    public ICommand Create(JsonElement payload) => Create(payload);
+
+    public void OnLoaded(IServiceProvider services) { }
+}

--- a/plugins/handlers/CcmExecHandler/CcmExecHandler.csproj
+++ b/plugins/handlers/CcmExecHandler/CcmExecHandler.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/plugins/handlers/CcmExecHandler/CcmSchedules.cs
+++ b/plugins/handlers/CcmExecHandler/CcmSchedules.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace CcmExecHandler;
+
+internal static class CcmSchedules
+{
+    private static readonly Dictionary<string, string> ScheduleIds = new()
+    {
+        ["machine-policy"] = "{00000000-0000-0000-0000-000000000021}",
+        ["user-policy"] = "{00000000-0000-0000-0000-000000000027}",
+        ["hardware-inventory"] = "{00000000-0000-0000-0000-000000000001}",
+        ["software-inventory"] = "{00000000-0000-0000-0000-000000000002}",
+        ["discovery-data"] = "{00000000-0000-0000-0000-000000000003}",
+        ["app-deploy-eval"] = "{00000000-0000-0000-0000-000000000121}",
+        ["software-update-scan"] = "{00000000-0000-0000-0000-000000000113}",
+    };
+
+    public static bool TryGetScheduleId(string task, out string id) =>
+        ScheduleIds.TryGetValue(task.ToLowerInvariant(), out id);
+}

--- a/plugins/handlers/CcmExecHandler/TriggerScheduleCommand.cs
+++ b/plugins/handlers/CcmExecHandler/TriggerScheduleCommand.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.WebSockets;
+using TaskHub.Abstractions;
+
+namespace CcmExecHandler;
+
+public class TriggerScheduleCommand : ICommand
+{
+    public TriggerScheduleCommand(TriggerScheduleRequest request)
+    {
+        Request = request;
+    }
+
+    public TriggerScheduleRequest Request { get; }
+
+    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken, ClientWebSocket? socket = null)
+    {
+        if (!CcmSchedules.TryGetScheduleId(Request.Task, out var scheduleId))
+        {
+            var error = JsonSerializer.SerializeToElement($"Unknown task '{Request.Task}'");
+            return Task.FromResult(new OperationResult(error, "unknown-task"));
+        }
+
+        dynamic cm = service.GetService();
+        var parameters = new Dictionary<string, object?> { ["sScheduleID"] = scheduleId };
+        OperationResult result = cm.InvokeMethod(".", "root\\ccm", "SMS_Client", "TriggerSchedule", parameters);
+        return Task.FromResult(result);
+    }
+}

--- a/plugins/handlers/CcmExecHandler/TriggerScheduleRequest.cs
+++ b/plugins/handlers/CcmExecHandler/TriggerScheduleRequest.cs
@@ -1,0 +1,6 @@
+namespace CcmExecHandler;
+
+public class TriggerScheduleRequest
+{
+    public string Task { get; set; } = "machine-policy";
+}

--- a/tests/CcmExecHandler.Tests/CcmExecCommandHandlerTests.cs
+++ b/tests/CcmExecHandler.Tests/CcmExecCommandHandlerTests.cs
@@ -1,0 +1,15 @@
+using CcmExecHandler;
+using Xunit;
+
+namespace CcmExecHandler.Tests;
+
+public class CcmExecCommandHandlerTests
+{
+    [Fact]
+    public void CommandsIncludeCcmExwc()
+    {
+        var handler = new CcmExecCommandHandler();
+        Assert.Contains("ccmexwc", handler.Commands);
+        Assert.Equal("configurationmanager", handler.ServiceName);
+    }
+}

--- a/tests/CcmExecHandler.Tests/CcmExecHandler.Tests.csproj
+++ b/tests/CcmExecHandler.Tests/CcmExecHandler.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\CcmExecHandler\\CcmExecHandler.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add handler for triggering common Configuration Manager client tasks through `ccmexwc`
- support scheduling actions like machine policy or inventory via `TriggerSchedule`
- cover handler with basic command metadata test

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aca52cbaf08321b9f5b97433b15f23