### PR TITLE
Add monitor info handler using EDID

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -67,6 +67,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntuneManagementExtensionHa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntuneManagementExtensionHandler.Tests", "tests/IntuneManagementExtensionHandler.Tests/IntuneManagementExtensionHandler.Tests.csproj", "{02B9C9D0-15EB-4F1A-930A-C6D61CA2C273}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonitorServicePlugin", "plugins/services/MonitorServicePlugin/MonitorServicePlugin.csproj", "{A9E5DBB2-7CCB-4984-890F-EF462A46AF09}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonitorHandler", "plugins/handlers/MonitorHandler/MonitorHandler.csproj", "{6C0F4FB0-A714-42C2-84E9-F555F10CBBF5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonitorHandler.Tests", "tests/MonitorHandler.Tests/MonitorHandler.Tests.csproj", "{E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -201,6 +207,18 @@ Global
         {02B9C9D0-15EB-4F1A-930A-C6D61CA2C273}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {02B9C9D0-15EB-4F1A-930A-C6D61CA2C273}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {02B9C9D0-15EB-4F1A-930A-C6D61CA2C273}.Release|Any CPU.Build.0 = Release|Any CPU
+        {A9E5DBB2-7CCB-4984-890F-EF462A46AF09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {A9E5DBB2-7CCB-4984-890F-EF462A46AF09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {A9E5DBB2-7CCB-4984-890F-EF462A46AF09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {A9E5DBB2-7CCB-4984-890F-EF462A46AF09}.Release|Any CPU.Build.0 = Release|Any CPU
+        {6C0F4FB0-A714-42C2-84E9-F555F10CBBF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {6C0F4FB0-A714-42C2-84E9-F555F10CBBF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {6C0F4FB0-A714-42C2-84E9-F555F10CBBF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {6C0F4FB0-A714-42C2-84E9-F555F10CBBF5}.Release|Any CPU.Build.0 = Release|Any CPU
+        {E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/MonitorHandler/MonitorCommandHandler.cs
+++ b/plugins/handlers/MonitorHandler/MonitorCommandHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace MonitorHandler;
+
+public class MonitorCommandHandler : ICommandHandler<MonitorInfoCommand>
+{
+    public IReadOnlyCollection<string> Commands => new[] { "monitor-info" };
+    public string ServiceName => "monitor";
+
+    public MonitorInfoCommand Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<MonitorInfoRequest>(payload.GetRawText()) ?? new MonitorInfoRequest();
+        return new MonitorInfoCommand(request);
+    }
+
+    ICommand ICommandHandler.Create(JsonElement payload) => Create(payload);
+
+    public void OnLoaded(IServiceProvider services) { }
+}
+

--- a/plugins/handlers/MonitorHandler/MonitorHandler.csproj
+++ b/plugins/handlers/MonitorHandler/MonitorHandler.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <ProjectReference Include="..\\..\\services\\MonitorServicePlugin\\MonitorServicePlugin.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/plugins/handlers/MonitorHandler/MonitorInfoCommand.cs
+++ b/plugins/handlers/MonitorHandler/MonitorInfoCommand.cs
@@ -1,0 +1,27 @@
+using System.Net.WebSockets;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MonitorServicePlugin;
+using TaskHub.Abstractions;
+
+namespace MonitorHandler;
+
+public class MonitorInfoCommand : ICommand
+{
+    public MonitorInfoCommand(MonitorInfoRequest request)
+    {
+        Request = request;
+    }
+
+    public MonitorInfoRequest Request { get; }
+
+    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken, ClientWebSocket? socket = null)
+    {
+        var monitorService = (MonitorService)service.GetService();
+        var monitors = monitorService.GetMonitors();
+        var element = JsonSerializer.SerializeToElement(monitors);
+        return Task.FromResult(new OperationResult(element, "success"));
+    }
+}
+

--- a/plugins/handlers/MonitorHandler/MonitorInfoRequest.cs
+++ b/plugins/handlers/MonitorHandler/MonitorInfoRequest.cs
@@ -1,0 +1,4 @@
+namespace MonitorHandler;
+
+public record MonitorInfoRequest();
+

--- a/plugins/services/MonitorServicePlugin/MonitorService.cs
+++ b/plugins/services/MonitorServicePlugin/MonitorService.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace MonitorServicePlugin;
+
+public class MonitorService
+{
+    public IEnumerable<MonitorInfo> GetMonitors()
+    {
+        var list = new List<MonitorInfo>();
+        try
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                using var searcher = new ManagementObjectSearcher(@"root\\WMI", "SELECT * FROM WmiMonitorDescriptor");
+                foreach (ManagementObject mo in searcher.Get())
+                {
+                    try
+                    {
+                        var type = (ushort)(mo["DescriptorType"] ?? 0);
+                        if (type != 1) continue; // 1 indicates EDID
+                        if (mo["Descriptor"] is byte[] edid)
+                        {
+                            var info = ParseEdid(edid);
+                            if (info != null) list.Add(info);
+                        }
+                    }
+                    catch
+                    {
+                        // ignore malformed entries
+                    }
+                }
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                foreach (var file in Directory.EnumerateFiles("/sys/class/drm", "edid", SearchOption.AllDirectories))
+                {
+                    try
+                    {
+                        var edid = File.ReadAllBytes(file);
+                        var info = ParseEdid(edid);
+                        if (info != null) list.Add(info);
+                    }
+                    catch
+                    {
+                        // ignore errors reading individual files
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // ignore failures on unsupported platforms
+        }
+        return list;
+    }
+
+    private static MonitorInfo? ParseEdid(byte[] edid)
+    {
+        if (edid.Length < 128) return null;
+        string manufacturer = ParseManufacturer((ushort)((edid[8] << 8) | edid[9]));
+        string serial = BitConverter.ToString(edid, 12, 4).Replace("-", string.Empty);
+        string model = string.Empty;
+
+        for (int i = 54; i <= 108; i += 18)
+        {
+            if (edid[i] == 0x00 && edid[i + 1] == 0x00 && edid[i + 3] == 0xFC)
+            {
+                model = Encoding.ASCII.GetString(edid, i + 5, 13).Trim('\0', '\n', '\r', ' ');
+                break;
+            }
+        }
+
+        if (string.IsNullOrEmpty(model))
+        {
+            model = (edid[11] << 8 | edid[10]).ToString("X4");
+        }
+
+        return new MonitorInfo(manufacturer, model, serial);
+    }
+
+    private static string ParseManufacturer(ushort code)
+    {
+        char c1 = (char)('A' + ((code >> 10) & 0x1F) - 1);
+        char c2 = (char)('A' + ((code >> 5) & 0x1F) - 1);
+        char c3 = (char)('A' + (code & 0x1F) - 1);
+        return new string(new[] { c1, c2, c3 });
+    }
+
+    public record MonitorInfo(string Manufacturer, string Model, string SerialNumber);
+}
+

--- a/plugins/services/MonitorServicePlugin/MonitorServicePlugin.cs
+++ b/plugins/services/MonitorServicePlugin/MonitorServicePlugin.cs
@@ -1,0 +1,13 @@
+using TaskHub.Abstractions;
+
+namespace MonitorServicePlugin;
+
+public class MonitorServicePlugin : IServicePlugin
+{
+    private readonly MonitorService _service = new();
+
+    public string Name => "monitor";
+
+    public object GetService() => _service;
+}
+

--- a/plugins/services/MonitorServicePlugin/MonitorServicePlugin.csproj
+++ b/plugins/services/MonitorServicePlugin/MonitorServicePlugin.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/tests/MonitorHandler.Tests/MonitorCommandHandlerTests.cs
+++ b/tests/MonitorHandler.Tests/MonitorCommandHandlerTests.cs
@@ -1,0 +1,16 @@
+using MonitorHandler;
+using Xunit;
+
+namespace MonitorHandler.Tests;
+
+public class MonitorCommandHandlerTests
+{
+    [Fact]
+    public void CommandsIncludeMonitorInfo()
+    {
+        var handler = new MonitorCommandHandler();
+        Assert.Contains("monitor-info", handler.Commands);
+        Assert.Equal("monitor", handler.ServiceName);
+    }
+}
+

--- a/tests/MonitorHandler.Tests/MonitorHandler.Tests.csproj
+++ b/tests/MonitorHandler.Tests/MonitorHandler.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\MonitorHandler\\MonitorHandler.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add monitor service plugin parsing EDID data from Windows WMI or Linux sysfs
- implement monitor-info handler to expose connected monitor details
- cover command registration with new unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace1c6a8a88321b5f6b15ba2d7b3f0