### PR TITLE
Add handler for executing PowerShell scripts

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -73,6 +73,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonitorHandler", "plugins/h
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonitorHandler.Tests", "tests/MonitorHandler.Tests/MonitorHandler.Tests.csproj", "{E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerShellHandler", "plugins/handlers/PowerShellHandler/PowerShellHandler.csproj", "{AE0493D8-BCAB-4127-9334-873DA3A66FC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerShellHandler.Tests", "tests/PowerShellHandler.Tests/PowerShellHandler.Tests.csproj", "{14CFDE9C-31FF-4F91-9474-B202E7E30160}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -219,6 +223,14 @@ Global
         {E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {E80A5E92-76BC-4259-8B04-F4E7C8FDBB5B}.Release|Any CPU.Build.0 = Release|Any CPU
+        {AE0493D8-BCAB-4127-9334-873DA3A66FC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {AE0493D8-BCAB-4127-9334-873DA3A66FC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {AE0493D8-BCAB-4127-9334-873DA3A66FC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {AE0493D8-BCAB-4127-9334-873DA3A66FC4}.Release|Any CPU.Build.0 = Release|Any CPU
+        {14CFDE9C-31FF-4F91-9474-B202E7E30160}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {14CFDE9C-31FF-4F91-9474-B202E7E30160}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {14CFDE9C-31FF-4F91-9474-B202E7E30160}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {14CFDE9C-31FF-4F91-9474-B202E7E30160}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/BitLockerHandler/BitLockerCommandHandler.cs
+++ b/plugins/handlers/BitLockerHandler/BitLockerCommandHandler.cs
@@ -11,13 +11,13 @@ using TaskHub.Abstractions;
 
 namespace BitLockerHandler;
 
-public class BitLockerCommandHandler : ICommandHandler<RotateKeyCommand>
+public class BitLockerCommandHandler : CommandHandlerBase, ICommandHandler<RotateKeyCommand>
 {
     private static HubConnection? _connection;
     private static BitLockerService? _service;
 
-    public IReadOnlyCollection<string> Commands => new[] { "bitlocker-rotate" };
-    public string ServiceName => "bitlocker";
+    public override IReadOnlyCollection<string> Commands => new[] { "bitlocker-rotate" };
+    public override string ServiceName => "bitlocker";
 
     public RotateKeyCommand Create(JsonElement payload)
     {
@@ -25,9 +25,9 @@ public class BitLockerCommandHandler : ICommandHandler<RotateKeyCommand>
         return new RotateKeyCommand(request);
     }
 
-    public ICommand Create(JsonElement payload) => Create(payload);
+    public override ICommand Create(JsonElement payload) => Create(payload);
 
-    public void OnLoaded(IServiceProvider services)
+    public override void OnLoaded(IServiceProvider services)
     {
         var logger = services.GetRequiredService<ILogger<BitLockerService>>();
         var config = services.GetService<IConfiguration>();

--- a/plugins/handlers/CcmExecHandler/CcmExecCommandHandler.cs
+++ b/plugins/handlers/CcmExecHandler/CcmExecCommandHandler.cs
@@ -5,10 +5,10 @@ using TaskHub.Abstractions;
 
 namespace CcmExecHandler;
 
-public class CcmExecCommandHandler : ICommandHandler<TriggerScheduleCommand>
+public class CcmExecCommandHandler : CommandHandlerBase, ICommandHandler<TriggerScheduleCommand>
 {
-    public IReadOnlyCollection<string> Commands => new[] { "ccmexwc" };
-    public string ServiceName => "configurationmanager";
+    public override IReadOnlyCollection<string> Commands => new[] { "ccmexwc" };
+    public override string ServiceName => "configurationmanager";
 
     public TriggerScheduleCommand Create(JsonElement payload)
     {
@@ -17,7 +17,7 @@ public class CcmExecCommandHandler : ICommandHandler<TriggerScheduleCommand>
         return new TriggerScheduleCommand(request);
     }
 
-    public ICommand Create(JsonElement payload) => Create(payload);
+    public override ICommand Create(JsonElement payload) => Create(payload);
 
-    public void OnLoaded(IServiceProvider services) { }
+    public override void OnLoaded(IServiceProvider services) { }
 }

--- a/plugins/handlers/CleanTempHandler/CleanTempCommandHandler.cs
+++ b/plugins/handlers/CleanTempHandler/CleanTempCommandHandler.cs
@@ -10,11 +10,12 @@ using TaskHub.Server;
 namespace CleanTempHandler;
 
 public class CleanTempCommandHandler :
+    CommandHandlerBase,
     ICommandHandler<CleanTempCommand>,
     ICommandHandler<DeleteFolderCommand>
 {
-    public IReadOnlyCollection<string> Commands => new[] { "clean-temp", "delete-folder" };
-    public string ServiceName => "filesystem";
+    public override IReadOnlyCollection<string> Commands => new[] { "clean-temp", "delete-folder" };
+    public override string ServiceName => "filesystem";
 
     CleanTempCommand ICommandHandler<CleanTempCommand>.Create(JsonElement payload)
     {
@@ -30,10 +31,10 @@ public class CleanTempCommandHandler :
         return new DeleteFolderCommand(request);
     }
 
-    public ICommand Create(JsonElement payload) =>
+    public override ICommand Create(JsonElement payload) =>
         ((ICommandHandler<CleanTempCommand>)this).Create(payload);
 
-    public void OnLoaded(IServiceProvider services)
+    public override void OnLoaded(IServiceProvider services)
     {
         var recurringJobs = services.GetRequiredService<IRecurringJobManager>();
         var payload = JsonSerializer.Deserialize<JsonElement>("{}");

--- a/plugins/handlers/EchoHandler/EchoCommandHandler.cs
+++ b/plugins/handlers/EchoHandler/EchoCommandHandler.cs
@@ -5,10 +5,10 @@ using TaskHub.Abstractions;
 
 namespace EchoHandler;
 
-public class EchoCommandHandler : ICommandHandler<EchoCommand>
+public class EchoCommandHandler : CommandHandlerBase, ICommandHandler<EchoCommand>
 {
-    public IReadOnlyCollection<string> Commands => new[] { "echo" };
-    public string ServiceName => "http";
+    public override IReadOnlyCollection<string> Commands => new[] { "echo" };
+    public override string ServiceName => "http";
 
     public EchoCommand Create(JsonElement payload)
     {
@@ -17,6 +17,8 @@ public class EchoCommandHandler : ICommandHandler<EchoCommand>
         return new EchoCommand(request);
     }
 
-    public void OnLoaded(IServiceProvider services) { }
+    public override ICommand Create(JsonElement payload) => Create(payload);
+
+    public override void OnLoaded(IServiceProvider services) { }
 }
 

--- a/plugins/handlers/IntuneManagementExtensionHandler/IntuneManagementExtensionCommandHandler.cs
+++ b/plugins/handlers/IntuneManagementExtensionHandler/IntuneManagementExtensionCommandHandler.cs
@@ -5,10 +5,10 @@ using TaskHub.Abstractions;
 
 namespace IntuneManagementExtensionHandler;
 
-public class IntuneManagementExtensionCommandHandler : ICommandHandler<TriggerSyncCommand>
+public class IntuneManagementExtensionCommandHandler : CommandHandlerBase, ICommandHandler<TriggerSyncCommand>
 {
-    public IReadOnlyCollection<string> Commands => new[] { "intune-sync" };
-    public string ServiceName => "powershell";
+    public override IReadOnlyCollection<string> Commands => new[] { "intune-sync" };
+    public override string ServiceName => "powershell";
 
     public TriggerSyncCommand Create(JsonElement payload)
     {
@@ -16,7 +16,7 @@ public class IntuneManagementExtensionCommandHandler : ICommandHandler<TriggerSy
         return new TriggerSyncCommand(request);
     }
 
-    public ICommand Create(JsonElement payload) => Create(payload);
+    public override ICommand Create(JsonElement payload) => Create(payload);
 
-    public void OnLoaded(IServiceProvider services) { }
+    public override void OnLoaded(IServiceProvider services) { }
 }

--- a/plugins/handlers/MonitorHandler/MonitorCommandHandler.cs
+++ b/plugins/handlers/MonitorHandler/MonitorCommandHandler.cs
@@ -5,10 +5,10 @@ using TaskHub.Abstractions;
 
 namespace MonitorHandler;
 
-public class MonitorCommandHandler : ICommandHandler<MonitorInfoCommand>
+public class MonitorCommandHandler : CommandHandlerBase, ICommandHandler<MonitorInfoCommand>
 {
-    public IReadOnlyCollection<string> Commands => new[] { "monitor-info" };
-    public string ServiceName => "monitor";
+    public override IReadOnlyCollection<string> Commands => new[] { "monitor-info" };
+    public override string ServiceName => "monitor";
 
     public MonitorInfoCommand Create(JsonElement payload)
     {
@@ -16,8 +16,8 @@ public class MonitorCommandHandler : ICommandHandler<MonitorInfoCommand>
         return new MonitorInfoCommand(request);
     }
 
-    ICommand ICommandHandler.Create(JsonElement payload) => Create(payload);
+    public override ICommand Create(JsonElement payload) => Create(payload);
 
-    public void OnLoaded(IServiceProvider services) { }
+    public override void OnLoaded(IServiceProvider services) { }
 }
 

--- a/plugins/handlers/PowerShellHandler/PowerShellCommand.cs
+++ b/plugins/handlers/PowerShellHandler/PowerShellCommand.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace PowerShellHandler;
+
+public class PowerShellCommand : ICommand
+{
+    private readonly IServicePlugin _service;
+
+    public PowerShellCommand(IServicePlugin service, PowerShellScriptRequest request)
+    {
+        _service = service;
+        Request = request;
+    }
+
+    public PowerShellScriptRequest Request { get; }
+
+    public Task<OperationResult> ExecuteAsync(CancellationToken cancellationToken)
+    {
+        var scriptBase64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(Request.Script));
+        dynamic ps = _service.GetService();
+        OperationResult result = ps.Execute(scriptBase64, Request.Version, Request.Properties);
+        return Task.FromResult(result);
+    }
+
+    Task<OperationResult> ICommand.ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken, ClientWebSocket? socket)
+        => ExecuteAsync(cancellationToken);
+}

--- a/plugins/handlers/PowerShellHandler/PowerShellCommandHandler.cs
+++ b/plugins/handlers/PowerShellHandler/PowerShellCommandHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+using PowerShellServicePlugin;
+
+namespace PowerShellHandler;
+
+public class PowerShellCommandHandler : CommandHandlerBase, ICommandHandler<PowerShellCommand>
+{
+    private readonly IServicePlugin _service;
+
+    public PowerShellCommandHandler(PowerShellServicePlugin.PowerShellServicePlugin service)
+    {
+        _service = service;
+    }
+
+    public override IReadOnlyCollection<string> Commands => new[] { "powershell-script" };
+    public override string ServiceName => "powershell";
+
+    public PowerShellCommand Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<PowerShellScriptRequest>(payload.GetRawText())
+                      ?? new PowerShellScriptRequest();
+        return new PowerShellCommand(_service, request);
+    }
+
+    public override ICommand Create(JsonElement payload) => Create(payload);
+
+    public override void OnLoaded(IServiceProvider services) { }
+}

--- a/plugins/handlers/PowerShellHandler/PowerShellHandler.csproj
+++ b/plugins/handlers/PowerShellHandler/PowerShellHandler.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/plugins/handlers/PowerShellHandler/PowerShellScriptRequest.cs
+++ b/plugins/handlers/PowerShellHandler/PowerShellScriptRequest.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace PowerShellHandler;
+
+public class PowerShellScriptRequest
+{
+    public string Script { get; set; } = string.Empty;
+    public string? Version { get; set; }
+    public Dictionary<string, object>? Properties { get; set; }
+}

--- a/src/TaskHub.Abstractions/CommandHandlerBase.cs
+++ b/src/TaskHub.Abstractions/CommandHandlerBase.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TaskHub.Abstractions;
+
+public abstract class CommandHandlerBase : ICommandHandler
+{
+    public abstract IReadOnlyCollection<string> Commands { get; }
+    public abstract string ServiceName { get; }
+    public abstract ICommand Create(JsonElement payload);
+    public abstract void OnLoaded(IServiceProvider services);
+
+    public virtual async Task<OperationResult> ExecuteAsync(
+        JsonElement payload,
+        IServicePlugin service,
+        ClientWebSocket? socket,
+        CancellationToken cancellationToken)
+    {
+        var command = Create(payload);
+        var result = await command.ExecuteAsync(service, cancellationToken);
+        if (socket != null)
+        {
+            var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(result));
+            await socket.SendAsync(
+                new ArraySegment<byte>(bytes),
+                WebSocketMessageType.Text,
+                true,
+                cancellationToken);
+        }
+
+        return result;
+    }
+}

--- a/src/TaskHub.Abstractions/Interfaces/ICommandHandler.cs
+++ b/src/TaskHub.Abstractions/Interfaces/ICommandHandler.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Net.WebSockets;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace TaskHub.Abstractions;
 
@@ -10,6 +13,12 @@ public interface ICommandHandler
     string ServiceName { get; }
     ICommand Create(JsonElement payload);
     void OnLoaded(IServiceProvider services);
+
+    Task<OperationResult> ExecuteAsync(
+        JsonElement payload,
+        IServicePlugin service,
+        ClientWebSocket? socket,
+        CancellationToken cancellationToken);
 }
 
 public interface ICommandHandler<out TCommand> : ICommandHandler where TCommand : ICommand

--- a/src/TaskHub.Server/CommandExecutor.cs
+++ b/src/TaskHub.Server/CommandExecutor.cs
@@ -35,8 +35,7 @@ namespace TaskHub.Server;
         }
 
         var service = _manager.GetService(handler.ServiceName);
-        var cmd = handler.Create(payload);
-        return await cmd.ExecuteAsync(service, token, socket);
+        return await handler.ExecuteAsync(payload, service, socket, token);
     }
 
     public async Task<OperationResult> Execute(string command, JsonElement payload, CancellationToken token, ClientWebSocket? socket = null)

--- a/tests/PowerShellHandler.Tests/PowerShellCommandHandlerTests.cs
+++ b/tests/PowerShellHandler.Tests/PowerShellCommandHandlerTests.cs
@@ -1,0 +1,36 @@
+using PowerShellHandler;
+using PowerShellServicePlugin;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json;
+using Xunit;
+
+namespace PowerShellHandler.Tests;
+
+public class PowerShellCommandHandlerTests
+{
+    [Fact]
+    public void CommandsIncludePowerShellScript()
+    {
+        var plugin = new PowerShellServicePlugin.PowerShellServicePlugin();
+        var handler = new PowerShellCommandHandler(plugin);
+        Assert.Contains("powershell-script", handler.Commands);
+        Assert.Equal("powershell", handler.ServiceName);
+    }
+
+    [Fact]
+    public async Task ExecutesScript()
+    {
+        var plugin = new PowerShellServicePlugin.PowerShellServicePlugin();
+        var handler = new PowerShellCommandHandler(plugin);
+        var request = new PowerShellScriptRequest { Script = "Write-Output 5" };
+        var payload = JsonSerializer.SerializeToElement(request);
+
+        var result = await handler.ExecuteAsync(payload, plugin, null, CancellationToken.None);
+        Assert.Equal("success", result.Result);
+        var element = result.Payload!.Value;
+        var first = element.EnumerateArray().First();
+        Assert.Equal(5, first.GetInt32());
+    }
+}

--- a/tests/PowerShellHandler.Tests/PowerShellHandler.Tests.csproj
+++ b/tests/PowerShellHandler.Tests/PowerShellHandler.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\PowerShellHandler\\PowerShellHandler.csproj" />
+    <ProjectReference Include="..\\..\\plugins\\services\\PowerShellServicePlugin\\PowerShellServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/TaskHub.Server.Tests/PluginManagerTests.cs
+++ b/tests/TaskHub.Server.Tests/PluginManagerTests.cs
@@ -79,12 +79,12 @@ public class PluginManagerTests
         }
     }
 
-    private class StubHandler : ICommandHandler<StubCommand>
+    private class StubHandler : CommandHandlerBase, ICommandHandler<StubCommand>
     {
-        public IReadOnlyCollection<string> Commands => new[] { "stub" };
-        public string ServiceName => "Stub";
+        public override IReadOnlyCollection<string> Commands => new[] { "stub" };
+        public override string ServiceName => "Stub";
         public StubCommand Create(System.Text.Json.JsonElement payload) => new StubCommand();
-        ICommand ICommandHandler.Create(System.Text.Json.JsonElement payload) => Create(payload);
-        public void OnLoaded(IServiceProvider services) { }
+        public override ICommand Create(System.Text.Json.JsonElement payload) => Create(payload);
+        public override void OnLoaded(IServiceProvider services) { }
     }
 }


### PR DESCRIPTION
## Summary
- route command execution results through the handler, sending them over an optional ClientWebSocket
- adjust CommandExecutor to invoke handler execution and propagate WebSocket results
- simplify PowerShell command so it no longer accepts a socket parameter
- extract shared handler execution logic into a new `CommandHandlerBase` and update handlers to inherit from it

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace8e600f483218da5b7a7aec1fb1d