### PR TITLE
Add Configuration Manager handler for admin or WMI

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -77,6 +77,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerShellHandler", "plugin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PowerShellHandler.Tests", "tests/PowerShellHandler.Tests/PowerShellHandler.Tests.csproj", "{14CFDE9C-31FF-4F91-9474-B202E7E30160}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerHandler", "plugins/handlers/ConfigurationManagerHandler/ConfigurationManagerHandler.csproj", "{478230BF-D1C9-46B1-8831-CA806101AC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerHandler.Tests", "tests/ConfigurationManagerHandler.Tests/ConfigurationManagerHandler.Tests.csproj", "{ED168547-8FEB-490E-897B-93FE3290A030}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -231,6 +235,14 @@ Global
         {14CFDE9C-31FF-4F91-9474-B202E7E30160}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {14CFDE9C-31FF-4F91-9474-B202E7E30160}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {14CFDE9C-31FF-4F91-9474-B202E7E30160}.Release|Any CPU.Build.0 = Release|Any CPU
+        {478230BF-D1C9-46B1-8831-CA806101AC19}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {478230BF-D1C9-46B1-8831-CA806101AC19}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {478230BF-D1C9-46B1-8831-CA806101AC19}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {478230BF-D1C9-46B1-8831-CA806101AC19}.Release|Any CPU.Build.0 = Release|Any CPU
+        {ED168547-8FEB-490E-897B-93FE3290A030}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {ED168547-8FEB-490E-897B-93FE3290A030}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {ED168547-8FEB-490E-897B-93FE3290A030}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {ED168547-8FEB-490E-897B-93FE3290A030}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/ConfigurationManagerHandler/ConfigurationManagerCommandHandler.cs
+++ b/plugins/handlers/ConfigurationManagerHandler/ConfigurationManagerCommandHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using TaskHub.Abstractions;
+
+namespace ConfigurationManagerHandler;
+
+public class ConfigurationManagerCommandHandler : CommandHandlerBase, ICommandHandler<QueryCommand>
+{
+    private readonly bool _useAdminService;
+
+    public ConfigurationManagerCommandHandler(IConfiguration? config = null)
+    {
+        _useAdminService = config?.GetValue<bool>("PluginSettings:ConfigurationManager:UseAdminService") ?? false;
+    }
+
+    public override IReadOnlyCollection<string> Commands => new[] { "cm-query" };
+
+    public override string ServiceName => _useAdminService ? "configurationmanageradmin" : "configurationmanager";
+
+    public QueryCommand Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<QueryRequest>(payload.GetRawText()) ?? new QueryRequest();
+        return new QueryCommand(request, _useAdminService);
+    }
+
+    public override ICommand Create(JsonElement payload) => Create(payload);
+
+    public override void OnLoaded(IServiceProvider services) { }
+}

--- a/plugins/handlers/ConfigurationManagerHandler/ConfigurationManagerHandler.csproj
+++ b/plugins/handlers/ConfigurationManagerHandler/ConfigurationManagerHandler.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>

--- a/plugins/handlers/ConfigurationManagerHandler/QueryCommand.cs
+++ b/plugins/handlers/ConfigurationManagerHandler/QueryCommand.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace ConfigurationManagerHandler;
+
+public class QueryCommand : ICommand
+{
+    private readonly bool _useAdminService;
+
+    public QueryCommand(QueryRequest request, bool useAdminService)
+    {
+        Request = request;
+        _useAdminService = useAdminService;
+    }
+
+    public QueryRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    {
+        if (_useAdminService)
+        {
+            dynamic admin = service.GetService();
+            return await admin.Get(Request.BaseUrl ?? string.Empty, Request.Resource ?? string.Empty, cancellationToken);
+        }
+        else
+        {
+            dynamic wmi = service.GetService();
+            return wmi.Query(Request.Host ?? ".", Request.Namespace ?? "root\\cimv2", Request.Query ?? string.Empty);
+        }
+    }
+}

--- a/plugins/handlers/ConfigurationManagerHandler/QueryRequest.cs
+++ b/plugins/handlers/ConfigurationManagerHandler/QueryRequest.cs
@@ -1,0 +1,10 @@
+namespace ConfigurationManagerHandler;
+
+public class QueryRequest
+{
+    public string? BaseUrl { get; set; }
+    public string? Resource { get; set; }
+    public string? Host { get; set; }
+    public string? Namespace { get; set; }
+    public string? Query { get; set; }
+}

--- a/src/TaskHub.Server/appsettings.json
+++ b/src/TaskHub.Server/appsettings.json
@@ -18,6 +18,9 @@
       "Password": "password",
       "UseProcessContext": false
     },
+    "ConfigurationManager": {
+      "UseAdminService": false
+    },
     "Http": { },
     "Echo": { }
   }

--- a/tests/ConfigurationManagerHandler.Tests/ConfigurationManagerCommandHandlerTests.cs
+++ b/tests/ConfigurationManagerHandler.Tests/ConfigurationManagerCommandHandlerTests.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using ConfigurationManagerHandler;
+using Microsoft.Extensions.Configuration;
+using TaskHub.Abstractions;
+using Xunit;
+
+namespace ConfigurationManagerHandler.Tests;
+
+public class ConfigurationManagerCommandHandlerTests
+{
+    [Fact]
+    public void CommandsIncludeCmQuery()
+    {
+        var handler = new ConfigurationManagerCommandHandler();
+        Assert.Contains("cm-query", handler.Commands);
+    }
+
+    [Fact]
+    public void ServiceNameReflectsConfiguration()
+    {
+        var adminConfig = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["PluginSettings:ConfigurationManager:UseAdminService"] = "true"
+        }).Build();
+        var adminHandler = new ConfigurationManagerCommandHandler(adminConfig);
+        Assert.Equal("configurationmanageradmin", adminHandler.ServiceName);
+
+        var wmiConfig = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["PluginSettings:ConfigurationManager:UseAdminService"] = "false"
+        }).Build();
+        var wmiHandler = new ConfigurationManagerCommandHandler(wmiConfig);
+        Assert.Equal("configurationmanager", wmiHandler.ServiceName);
+    }
+
+    [Fact]
+    public async Task ExecuteUsesAdminServiceWhenConfigured()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["PluginSettings:ConfigurationManager:UseAdminService"] = "true"
+        }).Build();
+        var handler = new ConfigurationManagerCommandHandler(config);
+        var request = new QueryRequest
+        {
+            BaseUrl = "http://localhost",
+            Resource = "test"
+        };
+        var payload = JsonSerializer.SerializeToElement(request);
+        var plugin = new FakeAdminServicePlugin();
+        await handler.ExecuteAsync(payload, plugin, CancellationToken.None);
+        Assert.True(plugin.Service.Called);
+        Assert.Equal("http://localhost", plugin.Service.BaseUrl);
+        Assert.Equal("test", plugin.Service.Resource);
+    }
+
+    [Fact]
+    public async Task ExecuteUsesWmiServiceWhenConfigured()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["PluginSettings:ConfigurationManager:UseAdminService"] = "false"
+        }).Build();
+        var handler = new ConfigurationManagerCommandHandler(config);
+        var request = new QueryRequest
+        {
+            Host = ".",
+            Namespace = "root\\cimv2",
+            Query = "SELECT * FROM Win32_ComputerSystem"
+        };
+        var payload = JsonSerializer.SerializeToElement(request);
+        var plugin = new FakeWmiServicePlugin();
+        var result = await handler.ExecuteAsync(payload, plugin, CancellationToken.None);
+        Assert.True(plugin.Service.Called);
+        Assert.Equal(".", plugin.Service.Host);
+        Assert.Equal("root\\cimv2", plugin.Service.Namespace);
+        Assert.Equal("SELECT * FROM Win32_ComputerSystem", plugin.Service.Query);
+        Assert.Equal("success", result.Result);
+    }
+
+    private class FakeAdminServicePlugin : IServicePlugin
+    {
+        public string Name => "configurationmanageradmin";
+        public FakeAdminService Service { get; } = new();
+        public object GetService() => Service;
+
+        public class FakeAdminService
+        {
+            public bool Called;
+            public string? BaseUrl;
+            public string? Resource;
+
+            public Task<OperationResult> Get(string baseUrl, string resource, CancellationToken cancellationToken = default)
+            {
+                Called = true;
+                BaseUrl = baseUrl;
+                Resource = resource;
+                return Task.FromResult(new OperationResult(null, "success"));
+            }
+        }
+    }
+
+    private class FakeWmiServicePlugin : IServicePlugin
+    {
+        public string Name => "configurationmanager";
+        public FakeWmiService Service { get; } = new();
+        public object GetService() => Service;
+
+        public class FakeWmiService
+        {
+            public bool Called;
+            public string? Host;
+            public string? Namespace;
+            public string? Query;
+
+            public OperationResult Query(string host, string wmiNamespace, string query)
+            {
+                Called = true;
+                Host = host;
+                Namespace = wmiNamespace;
+                Query = query;
+                return new OperationResult(null, "success");
+            }
+        }
+    }
+}

--- a/tests/ConfigurationManagerHandler.Tests/ConfigurationManagerHandler.Tests.csproj
+++ b/tests/ConfigurationManagerHandler.Tests/ConfigurationManagerHandler.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\ConfigurationManagerHandler\\ConfigurationManagerHandler.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Configure ConfigurationManager command handler to target admin or WMI service based on PluginSettings
- Route query execution to the selected service and remove request-time service flag
- Add plugin configuration sample and update tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfba51ca08321bfb89a4e145d52d2