### PR TITLE
Support versioned plugin directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The server exposes a minimal API:
 An OpenAPI/Swagger UI powered by NSwag is available at `/swagger`.
 
 Plugins must be compiled and copied under the `plugins` directory as described in the project.
+If multiple versions of a plugin exist in version-named subdirectories, the server loads the highest available version.
+Executed-command history includes the version of the plugin that handled each command.
 The `TaskHub.Abstractions` project contains shared interfaces and result types and can be packaged as a NuGet
 dependency for plugin development.
 

--- a/src/TaskHub.Abstractions/ExecutedCommandResult.cs
+++ b/src/TaskHub.Abstractions/ExecutedCommandResult.cs
@@ -9,5 +9,6 @@ namespace TaskHub.Abstractions;
 /// <param name="Command">Name of the executed command.</param>
 /// <param name="RanAt">Timestamp when the command was executed.</param>
 /// <param name="Output">Output returned by the command.</param>
-public record ExecutedCommandResult(string Command, DateTimeOffset RanAt, JsonElement Output);
+/// <param name="PluginVersion">Version of the plugin that handled the command.</param>
+public record ExecutedCommandResult(string Command, DateTimeOffset RanAt, JsonElement Output, string? PluginVersion = null);
 

--- a/tests/TaskHub.Server.Tests/PluginManagerTests.cs
+++ b/tests/TaskHub.Server.Tests/PluginManagerTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
+using HttpPlugin = HttpServicePlugin.HttpServicePlugin;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using TaskHub.Abstractions;
 using TaskHub.Server;
@@ -22,9 +25,9 @@ public class PluginManagerTests
     {
         var manager = CreateManager();
         var handlersField = typeof(PluginManager).GetField("_handlers", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var handlers = (Dictionary<string, (Type HandlerType, PluginLoadContext Context, string AssemblyPath)>)handlersField.GetValue(manager)!;
+        var handlers = (Dictionary<string, (Type HandlerType, PluginLoadContext Context, string AssemblyPath, Version? Version)>)handlersField.GetValue(manager)!;
         var path = typeof(StubHandler).Assembly.Location;
-        handlers["stub"] = (typeof(StubHandler), new PluginLoadContext(path), path);
+        handlers["stub"] = (typeof(StubHandler), new PluginLoadContext(path), path, new Version(1, 0));
 
         var handler = manager.GetHandler("stub");
 
@@ -41,13 +44,27 @@ public class PluginManagerTests
     }
 
     [Fact]
+    public void GetHandlerVersion_ReturnsVersion_WhenRegistered()
+    {
+        var manager = CreateManager();
+        var handlersField = typeof(PluginManager).GetField("_handlers", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var handlers = (Dictionary<string, (Type HandlerType, PluginLoadContext Context, string AssemblyPath, Version? Version)>)handlersField.GetValue(manager)!;
+        var path = typeof(StubHandler).Assembly.Location;
+        handlers["stub"] = (typeof(StubHandler), new PluginLoadContext(path), path, new Version(2, 1, 3));
+
+        var version = manager.GetHandlerVersion("stub");
+
+        Assert.Equal("2.1.3", version);
+    }
+
+    [Fact]
     public void GetService_ReturnsInstance_WhenRegistered()
     {
         var manager = CreateManager();
         var servicesField = typeof(PluginManager).GetField("_services", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var servicesDict = (Dictionary<string, (Type ServiceType, PluginLoadContext Context, string AssemblyPath)>)servicesField.GetValue(manager)!;
+        var servicesDict = (Dictionary<string, (Type ServiceType, PluginLoadContext Context, string AssemblyPath, Version? Version)>)servicesField.GetValue(manager)!;
         var path = typeof(StubServicePlugin).Assembly.Location;
-        servicesDict["Stub"] = (typeof(StubServicePlugin), new PluginLoadContext(path), path);
+        servicesDict["Stub"] = (typeof(StubServicePlugin), new PluginLoadContext(path), path, new Version(1, 0));
 
         var service = manager.GetService("Stub");
 
@@ -66,17 +83,65 @@ public class PluginManagerTests
     {
         var manager = CreateManager();
         var handlersField = typeof(PluginManager).GetField("_handlers", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        var handlers = (Dictionary<string, (Type HandlerType, PluginLoadContext Context, string AssemblyPath)>)handlersField.GetValue(manager)!;
+        var handlers = (Dictionary<string, (Type HandlerType, PluginLoadContext Context, string AssemblyPath, Version? Version)>)handlersField.GetValue(manager)!;
         var assembliesField = typeof(PluginManager).GetField("_assemblies", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var assemblies = (List<string>)assembliesField.GetValue(manager)!;
         var path = typeof(StubHandler).Assembly.Location;
-        handlers["stub"] = (typeof(StubHandler), new PluginLoadContext(path), path);
+        handlers["stub"] = (typeof(StubHandler), new PluginLoadContext(path), path, new Version(1, 0));
         assemblies.Add(path);
         manager.Unload(path);
 
         var handler = manager.GetHandler("stub");
         Assert.Null(handler);
         Assert.DoesNotContain(path, manager.LoadedAssemblies);
+    }
+
+    [Fact]
+    public void Load_UsesHighestVersion_WhenMultipleExist()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PluginSettings:http"] = string.Empty
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(config);
+        var provider = services.BuildServiceProvider();
+        var manager = new PluginManager(provider);
+
+        var root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var pluginRoot = Path.Combine(root, "services", "HttpServicePlugin");
+            var v1 = Path.Combine(pluginRoot, "1.0.0");
+            var v2 = Path.Combine(pluginRoot, "2.0.0");
+            Directory.CreateDirectory(v1);
+            Directory.CreateDirectory(v2);
+
+            var sourceDir = Path.GetDirectoryName(typeof(HttpPlugin).Assembly.Location)!;
+            foreach (var file in Directory.GetFiles(sourceDir))
+            {
+                var name = Path.GetFileName(file);
+                File.Copy(file, Path.Combine(v1, name));
+                File.Copy(file, Path.Combine(v2, name));
+            }
+
+            manager.Load(root);
+
+            var asm = Assert.Single(manager.LoadedAssemblies);
+            Assert.Contains("2.0.0", asm);
+
+            var service = manager.GetService("http");
+            Assert.IsType<HttpPlugin>(service);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
     }
 
     private class StubServicePlugin : IServicePlugin

--- a/tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj
+++ b/tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\\..\\src\\TaskHub.Server\\TaskHub.Server.csproj" />
+    <ProjectReference Include="..\\..\\plugins\\services\\HttpServicePlugin\\HttpServicePlugin.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">


### PR DESCRIPTION
## Summary
- track plugin versions when loading handlers and expose helper to query them
- include plugin version in `ExecutedCommandResult` and propagate through command execution
- document that command history now reports the executing plugin's version and test handler version retrieval

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4397baec8321994cb60e5a58292e