### PR TITLE
Add inventory reporting container and SignalR publishing

### DIFF
--- a/plugins/handlers/EchoHandler/EchoCommand.cs
+++ b/plugins/handlers/EchoHandler/EchoCommand.cs
@@ -9,9 +9,12 @@ namespace EchoHandler;
 
 public class EchoCommand : ICommand
 {
-    public EchoCommand(EchoRequest request)
+    private readonly IReportingContainer? _container;
+
+    public EchoCommand(EchoRequest request, IReportingContainer? container)
     {
         Request = request;
+        _container = container;
     }
 
     public EchoRequest Request { get; }
@@ -21,7 +24,9 @@ public class EchoCommand : ICommand
         var client = (HttpClient)service.GetService();
         var result = await client.GetStringAsync(Request.Resource, cancellationToken);
         Console.WriteLine($"Echo: {result}");
-        return new OperationResult(JsonSerializer.SerializeToElement(result), "success");
+        var element = JsonSerializer.SerializeToElement(result);
+        _container?.AddReport("echo", element);
+        return new OperationResult(element, "success");
     }
 }
 

--- a/plugins/handlers/EchoHandler/EchoCommandHandler.cs
+++ b/plugins/handlers/EchoHandler/EchoCommandHandler.cs
@@ -9,16 +9,20 @@ public class EchoCommandHandler : CommandHandlerBase, ICommandHandler<EchoComman
 {
     public override IReadOnlyCollection<string> Commands => new[] { "echo" };
     public override string ServiceName => "http";
+    private IReportingContainer? _reporting;
 
     public EchoCommand Create(JsonElement payload)
     {
         var request = JsonSerializer.Deserialize<EchoRequest>(payload.GetRawText())
                       ?? new EchoRequest();
-        return new EchoCommand(request);
+        return new EchoCommand(request, _reporting);
     }
 
     public override ICommand Create(JsonElement payload) => Create(payload);
 
-    public override void OnLoaded(IServiceProvider services) { }
+    public override void OnLoaded(IServiceProvider services)
+    {
+        _reporting = services.GetService<IReportingContainer>();
+    }
 }
 

--- a/plugins/handlers/MonitorHandler/MonitorCommandHandler.cs
+++ b/plugins/handlers/MonitorHandler/MonitorCommandHandler.cs
@@ -9,15 +9,19 @@ public class MonitorCommandHandler : CommandHandlerBase, ICommandHandler<Monitor
 {
     public override IReadOnlyCollection<string> Commands => new[] { "monitor-info" };
     public override string ServiceName => "monitor";
+    private IReportingContainer? _reporting;
 
     public MonitorInfoCommand Create(JsonElement payload)
     {
         var request = JsonSerializer.Deserialize<MonitorInfoRequest>(payload.GetRawText()) ?? new MonitorInfoRequest();
-        return new MonitorInfoCommand(request);
+        return new MonitorInfoCommand(request, _reporting);
     }
 
     public override ICommand Create(JsonElement payload) => Create(payload);
 
-    public override void OnLoaded(IServiceProvider services) { }
+    public override void OnLoaded(IServiceProvider services)
+    {
+        _reporting = services.GetService<IReportingContainer>();
+    }
 }
 

--- a/plugins/handlers/MonitorHandler/MonitorInfoCommand.cs
+++ b/plugins/handlers/MonitorHandler/MonitorInfoCommand.cs
@@ -8,9 +8,12 @@ namespace MonitorHandler;
 
 public class MonitorInfoCommand : ICommand
 {
-    public MonitorInfoCommand(MonitorInfoRequest request)
+    private readonly IReportingContainer? _container;
+
+    public MonitorInfoCommand(MonitorInfoRequest request, IReportingContainer? container)
     {
         Request = request;
+        _container = container;
     }
 
     public MonitorInfoRequest Request { get; }
@@ -20,6 +23,7 @@ public class MonitorInfoCommand : ICommand
         var monitorService = (MonitorService)service.GetService();
         var monitors = monitorService.GetMonitors();
         var element = JsonSerializer.SerializeToElement(monitors);
+        _container?.AddReport("monitor", element);
         return Task.FromResult(new OperationResult(element, "success"));
     }
 }

--- a/src/TaskHub.Abstractions/Interfaces/IReportingContainer.cs
+++ b/src/TaskHub.Abstractions/Interfaces/IReportingContainer.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace TaskHub.Abstractions;
+
+/// <summary>
+/// Collects inventory data from handlers for periodic reporting.
+/// </summary>
+public interface IReportingContainer
+{
+    /// <summary>
+    /// Add inventory data for later publishing.
+    /// </summary>
+    /// <param name="source">Name of the handler or source.</param>
+    /// <param name="data">The inventory payload.</param>
+    void AddReport(string source, JsonElement data);
+
+    /// <summary>
+    /// Retrieve and remove all pending reports.
+    /// </summary>
+    /// <returns>Collection of inventory reports.</returns>
+    IReadOnlyList<InventoryReport> DrainReports();
+}

--- a/src/TaskHub.Abstractions/InventoryReport.cs
+++ b/src/TaskHub.Abstractions/InventoryReport.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Text.Json;
+
+namespace TaskHub.Abstractions;
+
+/// <summary>
+/// Represents a unit of inventory data reported by a handler.
+/// </summary>
+/// <param name="Source">Name of the handler or source.</param>
+/// <param name="Data">Inventory payload.</param>
+/// <param name="CollectedAt">Timestamp when the inventory was collected.</param>
+public record InventoryReport(string Source, JsonElement Data, DateTimeOffset CollectedAt);

--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -18,6 +18,8 @@ builder.Services.AddSingleton<PluginManager>();
 builder.Services.AddSingleton<CommandExecutor>();
 builder.Services.AddSingleton<PayloadVerifier>();
 builder.Services.AddOpenApiDocument();
+builder.Services.AddSingleton<IReportingContainer, ReportingContainer>();
+builder.Services.AddHostedService<ReportingService>();
 
 var jobHandlingMode = builder.Configuration.GetValue<string>("JobHandling:Mode");
 if (string.Equals(jobHandlingMode, "WebSocket", StringComparison.OrdinalIgnoreCase))

--- a/src/TaskHub.Server/ReportingContainer.cs
+++ b/src/TaskHub.Server/ReportingContainer.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace TaskHub.Server;
+
+/// <summary>
+/// Thread-safe container for aggregating inventory reports from multiple handlers.
+/// </summary>
+public class ReportingContainer : IReportingContainer
+{
+    private readonly ConcurrentQueue<InventoryReport> _queue = new();
+
+    /// <inheritdoc />
+    public void AddReport(string source, JsonElement data)
+    {
+        _queue.Enqueue(new InventoryReport(source, data, DateTimeOffset.UtcNow));
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<InventoryReport> DrainReports()
+    {
+        var list = new List<InventoryReport>();
+        while (_queue.TryDequeue(out var report))
+        {
+            list.Add(report);
+        }
+        return list;
+    }
+}

--- a/src/TaskHub.Server/ReportingService.cs
+++ b/src/TaskHub.Server/ReportingService.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+
+namespace TaskHub.Server;
+
+/// <summary>
+/// Background service that periodically sends accumulated inventory reports
+/// to a SignalR hub.
+/// </summary>
+public class ReportingService : BackgroundService
+{
+    private readonly IReportingContainer _container;
+    private readonly ILogger<ReportingService> _logger;
+    private readonly IConfiguration _configuration;
+    private HubConnection? _connection;
+
+    public ReportingService(IReportingContainer container, IConfiguration configuration, ILogger<ReportingService> logger)
+    {
+        _container = container;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var url = _configuration["Reporting:HubUrl"];
+        if (string.IsNullOrEmpty(url))
+        {
+            _logger.LogWarning("Reporting hub URL is not configured.");
+            return;
+        }
+
+        _connection = new HubConnectionBuilder().WithUrl(url).Build();
+        await _connection.StartAsync(stoppingToken);
+
+        var intervalSeconds = _configuration.GetValue("Reporting:IntervalSeconds", 30);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var reports = _container.DrainReports();
+                if (reports.Count > 0)
+                {
+                    await _connection.SendAsync("ReportInventory", reports, stoppingToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send inventory reports");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(intervalSeconds), stoppingToken);
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_connection is not null)
+        {
+            await _connection.DisposeAsync();
+        }
+        await base.StopAsync(cancellationToken);
+    }
+}

--- a/src/TaskHub.Server/TaskHub.Server.csproj
+++ b/src/TaskHub.Server/TaskHub.Server.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.37" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.20.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\\..\\plugins\\**\\*.*">


### PR DESCRIPTION
## Summary
- introduce IReportingContainer and InventoryReport abstractions
- collect handler inventory data in ReportingContainer with timestamps
- send aggregated reports to SignalR hub periodically
- wire up example handlers (monitor, echo) to report inventory

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68af90a551488321b4fb21989879d089