### PR TITLE
Add disk space check service and handler

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -81,6 +81,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerHandler
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationManagerHandler.Tests", "tests/ConfigurationManagerHandler.Tests/ConfigurationManagerHandler.Tests.csproj", "{ED168547-8FEB-490E-897B-93FE3290A030}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiskSpaceHandler", "plugins/handlers/DiskSpaceHandler/DiskSpaceHandler.csproj", "{FFAFBBB3-6D20-4F7E-B3ED-E81E11FA619F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiskSpaceHandler.Tests", "tests/DiskSpaceHandler.Tests/DiskSpaceHandler.Tests.csproj", "{D5375916-D786-404E-B271-BCC353D520BF}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -243,6 +247,14 @@ Global
         {ED168547-8FEB-490E-897B-93FE3290A030}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {ED168547-8FEB-490E-897B-93FE3290A030}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {ED168547-8FEB-490E-897B-93FE3290A030}.Release|Any CPU.Build.0 = Release|Any CPU
+        {FFAFBBB3-6D20-4F7E-B3ED-E81E11FA619F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {FFAFBBB3-6D20-4F7E-B3ED-E81E11FA619F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {FFAFBBB3-6D20-4F7E-B3ED-E81E11FA619F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {FFAFBBB3-6D20-4F7E-B3ED-E81E11FA619F}.Release|Any CPU.Build.0 = Release|Any CPU
+        {D5375916-D786-404E-B271-BCC353D520BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {D5375916-D786-404E-B271-BCC353D520BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {D5375916-D786-404E-B271-BCC353D520BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {D5375916-D786-404E-B271-BCC353D520BF}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/DiskSpaceHandler/DiskSpaceCommand.cs
+++ b/plugins/handlers/DiskSpaceHandler/DiskSpaceCommand.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace DiskSpaceHandler;
+
+public class DiskSpaceCommand : ICommand
+{
+    private readonly IReportingContainer? _container;
+
+    public DiskSpaceCommand(DiskSpaceRequest request, IReportingContainer? container)
+    {
+        Request = request;
+        _container = container;
+    }
+
+    public DiskSpaceRequest Request { get; }
+
+    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    {
+        dynamic fs = service.GetService();
+        OperationResult result = fs.GetFreeSpace(Request.Path);
+        if (result.Payload.HasValue)
+        {
+            _container?.AddReport("disk-free", result.Payload.Value);
+        }
+        return Task.FromResult(result);
+    }
+}
+

--- a/plugins/handlers/DiskSpaceHandler/DiskSpaceCommandHandler.cs
+++ b/plugins/handlers/DiskSpaceHandler/DiskSpaceCommandHandler.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace DiskSpaceHandler;
+
+public class DiskSpaceCommandHandler : CommandHandlerBase, ICommandHandler<DiskSpaceCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[] { "disk-free" };
+    public override string ServiceName => "filesystem";
+    private IReportingContainer? _reporting;
+
+    public DiskSpaceCommand Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<DiskSpaceRequest>(payload.GetRawText()) ?? new DiskSpaceRequest();
+        return new DiskSpaceCommand(request, _reporting);
+    }
+
+    public override ICommand Create(JsonElement payload) => Create(payload);
+
+    public override void OnLoaded(IServiceProvider services)
+    {
+        _reporting = services.GetService<IReportingContainer>();
+    }
+}
+

--- a/plugins/handlers/DiskSpaceHandler/DiskSpaceHandler.csproj
+++ b/plugins/handlers/DiskSpaceHandler/DiskSpaceHandler.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+  <Target Name="CopyToRoot" AfterTargets="Build">
+    <ItemGroup>
+      <Assemblies Include="$(OutputPath)*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
+  </Target>
+</Project>
+

--- a/plugins/handlers/DiskSpaceHandler/DiskSpaceRequest.cs
+++ b/plugins/handlers/DiskSpaceHandler/DiskSpaceRequest.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace DiskSpaceHandler;
+
+public class DiskSpaceRequest
+{
+    [JsonPropertyName("path")]
+    public string Path { get; set; } = "/";
+}
+

--- a/plugins/services/FileSystemServicePlugin/FileSystemService.cs
+++ b/plugins/services/FileSystemServicePlugin/FileSystemService.cs
@@ -90,6 +90,24 @@ public class FileSystemServicePlugin : IServicePlugin
                 return new OperationResult(null, $"Failed to delete '{path}': {ex.Message}");
             }
         }
+
+        public OperationResult GetFreeSpace(string path)
+        {
+            try
+            {
+                var root = Path.GetPathRoot(Path.GetFullPath(path)) ?? path;
+                var drive = new DriveInfo(root);
+                var element = JsonSerializer.SerializeToElement(new
+                {
+                    freeBytes = drive.AvailableFreeSpace
+                });
+                return new OperationResult(element, "success");
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult(null, $"Failed to get free space for '{path}': {ex.Message}");
+            }
+        }
     }
 }
 

--- a/tests/DiskSpaceHandler.Tests/DiskSpaceCommandHandlerTests.cs
+++ b/tests/DiskSpaceHandler.Tests/DiskSpaceCommandHandlerTests.cs
@@ -1,0 +1,16 @@
+using DiskSpaceHandler;
+using Xunit;
+
+namespace DiskSpaceHandler.Tests;
+
+public class DiskSpaceCommandHandlerTests
+{
+    [Fact]
+    public void CommandsIncludeDiskFree()
+    {
+        var handler = new DiskSpaceCommandHandler();
+        Assert.Contains("disk-free", handler.Commands);
+        Assert.Equal("filesystem", handler.ServiceName);
+    }
+}
+

--- a/tests/DiskSpaceHandler.Tests/DiskSpaceHandler.Tests.csproj
+++ b/tests/DiskSpaceHandler.Tests/DiskSpaceHandler.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\DiskSpaceHandler\\DiskSpaceHandler.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+

--- a/tests/FileSystemServicePlugin.Tests/FileSystemServicePluginTests.cs
+++ b/tests/FileSystemServicePlugin.Tests/FileSystemServicePluginTests.cs
@@ -42,4 +42,13 @@ public class FileSystemServicePluginTests
         Assert.Throws<InvalidOperationException>(() => service.Write("/etc/passwd", "test"));
         Assert.Throws<InvalidOperationException>(() => service.Delete("/etc/passwd"));
     }
+
+    [Fact]
+    public void CanGetFreeSpace()
+    {
+        dynamic service = new FileSystemServicePlugin().GetService();
+        OperationResult result = service.GetFreeSpace(Path.GetTempPath());
+        Assert.Equal("success", result.Result);
+        Assert.True(result.Payload?.GetProperty("freeBytes").GetInt64() > 0);
+    }
 }


### PR DESCRIPTION
## Summary
- extend filesystem service with GetFreeSpace method to report available bytes
- introduce disk-free command handler that records disk space metrics to reporting
- cover service and handler with unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68af985eeda0832189164e939ebbf832