### PR TITLE
Fix compilation issues

### DIFF
--- a/plugins/handlers/BitLockerHandler/BitLockerCommandHandler.cs
+++ b/plugins/handlers/BitLockerHandler/BitLockerCommandHandler.cs
@@ -32,7 +32,7 @@ public class BitLockerCommandHandler : CommandHandlerBase, ICommandHandler<Rotat
     {
         var logger = services.GetRequiredService<ILogger<BitLockerService>>();
         var config = services.GetService<IConfiguration>();
-        var url = config?.GetValue<string>("PluginSettings:BitLocker:HubUrl") ?? "http://localhost/bitlocker";
+        var url = config?["PluginSettings:BitLocker:HubUrl"] ?? "http://localhost/bitlocker";
         _connection = new HubConnectionBuilder().WithUrl(url).Build();
         _ = _connection.StartAsync();
 

--- a/plugins/handlers/DiskSpaceHandler/DiskSpaceCommandHandler.cs
+++ b/plugins/handlers/DiskSpaceHandler/DiskSpaceCommandHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
 using TaskHub.Abstractions;
 
 namespace DiskSpaceHandler;
@@ -23,7 +22,7 @@ public class DiskSpaceCommandHandler : CommandHandlerBase, ICommandHandler<DiskS
 
     public override void OnLoaded(IServiceProvider services)
     {
-        _reporting = services.GetService<IReportingContainer>();
+        _reporting = (IReportingContainer?)services.GetService(typeof(IReportingContainer));
     }
 }
 

--- a/plugins/handlers/EchoHandler/EchoCommandHandler.cs
+++ b/plugins/handlers/EchoHandler/EchoCommandHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
 using TaskHub.Abstractions;
 
 namespace EchoHandler;
@@ -24,7 +23,7 @@ public class EchoCommandHandler : CommandHandlerBase, ICommandHandler<EchoComman
 
     public override void OnLoaded(IServiceProvider services)
     {
-        _reporting = services.GetService<IReportingContainer>();
+        _reporting = (IReportingContainer?)services.GetService(typeof(IReportingContainer));
     }
 }
 

--- a/plugins/handlers/MonitorHandler/MonitorCommandHandler.cs
+++ b/plugins/handlers/MonitorHandler/MonitorCommandHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
 using TaskHub.Abstractions;
 
 namespace MonitorHandler;
@@ -23,7 +22,7 @@ public class MonitorCommandHandler : CommandHandlerBase, ICommandHandler<Monitor
 
     public override void OnLoaded(IServiceProvider services)
     {
-        _reporting = services.GetService<IReportingContainer>();
+        _reporting = (IReportingContainer?)services.GetService(typeof(IReportingContainer));
     }
 }
 

--- a/src/TaskHub.Server/CommandEndpoints.cs
+++ b/src/TaskHub.Server/CommandEndpoints.cs
@@ -47,7 +47,13 @@ public static class CommandEndpoints
             }
             var jobId = Guid.NewGuid().ToString();
             var requestedBy = context.User.Identity?.Name ?? "anonymous";
-            client.Schedule(() => RecurringJob.AddOrUpdate<CommandExecutor>(jobId, exec => exec.ExecuteChain(request.Commands, request.Payload, requestedBy, null!, CancellationToken.None), request.CronExpression), request.Delay);
+            client.Schedule(() => RecurringJob.AddOrUpdate<CommandExecutor>(
+                jobId,
+                exec => exec.ExecuteChain(request.Commands, request.Payload, requestedBy, null!, CancellationToken.None),
+                request.CronExpression,
+                null,
+                "default"),
+                request.Delay);
             executor.SetCallback(jobId, request.CallbackConnectionId);
             logger.LogInformation("User {User} scheduled recurring job {JobId} for commands {Commands}", requestedBy, jobId, request.Commands);
             return Results.Ok(new EnqueuedCommandResult(jobId, Array.Empty<ExecutedCommandResult>(), DateTimeOffset.UtcNow.Add(request.Delay)));

--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -4,12 +4,14 @@ using System.Threading;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using Hangfire.Dashboard;
+using System.Net.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using TaskHub.Abstractions;
 using TaskHub.Server;
+using NSwag.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/tests/ConfigurationManagerHandler.Tests/ConfigurationManagerCommandHandlerTests.cs
+++ b/tests/ConfigurationManagerHandler.Tests/ConfigurationManagerCommandHandlerTests.cs
@@ -81,7 +81,7 @@ public class ConfigurationManagerCommandHandlerTests
         Assert.True(plugin.Service.QueryCalled);
         Assert.Equal(".", plugin.Service.Host);
         Assert.Equal("root\\cimv2", plugin.Service.Namespace);
-        Assert.Equal("SELECT * FROM Win32_ComputerSystem", plugin.Service.Query);
+        Assert.Equal("SELECT * FROM Win32_ComputerSystem", plugin.Service.QueryString);
         Assert.Equal("success", result.Result);
     }
 
@@ -287,7 +287,7 @@ public class ConfigurationManagerCommandHandlerTests
             public bool AddUserCalled;
             public string? Host;
             public string? Namespace;
-            public string? Query;
+            public string? QueryString;
             public string? Path;
             public string? Method;
             public Dictionary<string, object?>? Parameters;
@@ -302,7 +302,7 @@ public class ConfigurationManagerCommandHandlerTests
                 QueryCalled = true;
                 Host = host;
                 Namespace = wmiNamespace;
-                Query = query;
+                QueryString = query;
                 return new OperationResult(null, "success");
             }
 


### PR DESCRIPTION
## Summary
- Replace Microsoft.Extensions dependency usage in several command handlers with direct service lookups
- Add missing HttpClient and NSwag usings and specify optional parameters for recurring jobs
- Clarify test fake WMI service Query API to avoid member conflicts

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d33a26d88321b5afe7301f317ca4