### PR TITLE
Fix swagger ui usage and add configuration package for tests

### DIFF
--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -40,7 +40,7 @@ if (string.Equals(jobHandlingMode, "WebSocket", StringComparison.OrdinalIgnoreCa
 var app = builder.Build();
 
 app.UseOpenApi();
-app.UseSwaggerUi3();
+app.UseSwaggerUi();
 
 var dashboardUser = builder.Configuration["Hangfire:Username"] ?? string.Empty;
 var dashboardPass = builder.Configuration["Hangfire:Password"] ?? string.Empty;

--- a/src/TaskHub.Server/TaskHub.Server.csproj
+++ b/src/TaskHub.Server/TaskHub.Server.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.37" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.1" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.20.2" />
+    <PackageReference Include="NSwag.AspNetCore" Version="14.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/ConfigurationManagerHandler.Tests/ConfigurationManagerHandler.Tests.csproj
+++ b/tests/ConfigurationManagerHandler.Tests/ConfigurationManagerHandler.Tests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\\..\\plugins\\handlers\\ConfigurationManagerHandler\\ConfigurationManagerHandler.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- replace deprecated `UseSwaggerUi3` with `UseSwaggerUi`
- update NSwag.AspNetCore to version 14.0.0
- add Microsoft.Extensions.Configuration package to ConfigurationManagerHandler tests

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dc4c0adc83218b636f9156446c2a