### PR TITLE
Fix duplicate Create method in PluginManagerTests stub handler

### DIFF
--- a/tests/TaskHub.Server.Tests/PluginManagerTests.cs
+++ b/tests/TaskHub.Server.Tests/PluginManagerTests.cs
@@ -180,10 +180,12 @@ public class PluginManagerTests
     {
         public override IReadOnlyCollection<string> Commands => new[] { "stub" };
         public override string ServiceName => "Stub";
-        public StubCommand Create(JsonElement payload) =>
+        private StubCommand CreateCommand(JsonElement payload) =>
             new StubCommand(JsonSerializer.Deserialize<StubRequest>(payload.GetRawText()) ?? new StubRequest());
 
-        public override ICommand Create(JsonElement payload) => Create(payload);
+        public override ICommand Create(JsonElement payload) => CreateCommand(payload);
+
+        StubCommand ICommandHandler<StubCommand>.Create(JsonElement payload) => CreateCommand(payload);
         public override void OnLoaded(IServiceProvider services) { }
     }
 


### PR DESCRIPTION
## Summary
- Fix stub handler to avoid duplicate Create overload
- Explicitly implement ICommandHandler<StubCommand>.Create

## Testing
- `dotnet test tests/TaskHub.Server.Tests/TaskHub.Server.Tests.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dea579c48321bc58b6dd2552b53c