### PR TITLE
Copy plugin builds to dedicated folders

### DIFF
--- a/plugins/Directory.Build.targets
+++ b/plugins/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+  <Target Name="CopyToPluginsFolder" AfterTargets="Build">
+    <ItemGroup>
+      <PluginFiles Include="$(OutputPath)*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(PluginFiles)" DestinationFolder="$(MSBuildThisFileDirectory)$(MSBuildProjectName)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/plugins/handlers/BitLockerHandler/BitLockerHandler.csproj
+++ b/plugins/handlers/BitLockerHandler/BitLockerHandler.csproj
@@ -14,10 +14,4 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/handlers/CcmExecHandler/CcmExecHandler.csproj
+++ b/plugins/handlers/CcmExecHandler/CcmExecHandler.csproj
@@ -7,10 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/handlers/CleanTempHandler/CleanTempHandler.csproj
+++ b/plugins/handlers/CleanTempHandler/CleanTempHandler.csproj
@@ -8,10 +8,4 @@
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Server\\TaskHub.Server.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/handlers/ConfigurationManagerHandler/ConfigurationManagerHandler.csproj
+++ b/plugins/handlers/ConfigurationManagerHandler/ConfigurationManagerHandler.csproj
@@ -9,10 +9,4 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/handlers/DiskSpaceHandler/DiskSpaceHandler.csproj
+++ b/plugins/handlers/DiskSpaceHandler/DiskSpaceHandler.csproj
@@ -7,11 +7,5 @@
   <ItemGroup>
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>
 

--- a/plugins/handlers/EchoHandler/EchoHandler.csproj
+++ b/plugins/handlers/EchoHandler/EchoHandler.csproj
@@ -7,10 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/handlers/IntuneManagementExtensionHandler/IntuneManagementExtensionHandler.csproj
+++ b/plugins/handlers/IntuneManagementExtensionHandler/IntuneManagementExtensionHandler.csproj
@@ -7,10 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/handlers/MonitorHandler/MonitorHandler.csproj
+++ b/plugins/handlers/MonitorHandler/MonitorHandler.csproj
@@ -8,10 +8,4 @@
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
     <ProjectReference Include="..\\..\\services\\MonitorServicePlugin\\MonitorServicePlugin.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/handlers/PowerShellHandler/PowerShellHandler.csproj
+++ b/plugins/handlers/PowerShellHandler/PowerShellHandler.csproj
@@ -8,10 +8,4 @@
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
     <ProjectReference Include="..\\..\\services\\PowerShellServicePlugin\\PowerShellServicePlugin.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/ActiveDirectoryServicePlugin/ActiveDirectoryServicePlugin.csproj
+++ b/plugins/services/ActiveDirectoryServicePlugin/ActiveDirectoryServicePlugin.csproj
@@ -12,10 +12,4 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/BitLockerServicePlugin/BitLockerServicePlugin.csproj
+++ b/plugins/services/BitLockerServicePlugin/BitLockerServicePlugin.csproj
@@ -9,10 +9,4 @@
     <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/ConfigurationManagerAdminServicePlugin/ConfigurationManagerAdminServicePlugin.csproj
+++ b/plugins/services/ConfigurationManagerAdminServicePlugin/ConfigurationManagerAdminServicePlugin.csproj
@@ -7,10 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/ConfigurationManagerServicePlugin/ConfigurationManagerServicePlugin.csproj
+++ b/plugins/services/ConfigurationManagerServicePlugin/ConfigurationManagerServicePlugin.csproj
@@ -8,10 +8,4 @@
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
     <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/FileSystemServicePlugin/FileSystemServicePlugin.csproj
+++ b/plugins/services/FileSystemServicePlugin/FileSystemServicePlugin.csproj
@@ -11,10 +11,4 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/HttpServicePlugin/HttpServicePlugin.csproj
+++ b/plugins/services/HttpServicePlugin/HttpServicePlugin.csproj
@@ -10,10 +10,4 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/MonitorServicePlugin/MonitorServicePlugin.csproj
+++ b/plugins/services/MonitorServicePlugin/MonitorServicePlugin.csproj
@@ -8,10 +8,4 @@
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
     <PackageReference Include="System.Management" Version="8.0.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/MsGraphServicePlugin/MsGraphServicePlugin.csproj
+++ b/plugins/services/MsGraphServicePlugin/MsGraphServicePlugin.csproj
@@ -12,10 +12,4 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.15.0" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/PowerShellServicePlugin/PowerShellServicePlugin.csproj
+++ b/plugins/services/PowerShellServicePlugin/PowerShellServicePlugin.csproj
@@ -8,10 +8,4 @@
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.1" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/plugins/services/RegistryServicePlugin/RegistryServicePlugin.csproj
+++ b/plugins/services/RegistryServicePlugin/RegistryServicePlugin.csproj
@@ -7,10 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
   </ItemGroup>
-  <Target Name="CopyToRoot" AfterTargets="Build">
-    <ItemGroup>
-      <Assemblies Include="$(OutputPath)*.dll" />
-    </ItemGroup>
-    <Copy SourceFiles="@(Assemblies)" DestinationFolder="$(MSBuildProjectDirectory)" />
-  </Target>
-</Project>
+  </Project>

--- a/src/TaskHub.Server/TaskHub.Server.csproj
+++ b/src/TaskHub.Server/TaskHub.Server.csproj
@@ -12,10 +12,10 @@
     <PackageReference Include="NSwag.AspNetCore" Version="14.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\\..\\plugins\\**\\*.*"
-             Exclude="..\\..\\plugins\\**\\bin\\**;..\\..\\plugins\\**\\obj\\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+    <ItemGroup>
+      <Content Include="..\\..\\plugins\\*\\**\\*.*"
+               Exclude="..\\..\\plugins\\handlers\\**;..\\..\\plugins\\services\\**">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- route plugin build output through bin then copy to dedicated folder under `plugins`
- update server plugin include path to consume new plugin structure

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b34f53b1f08321b6b376ebb25ae9fb