### PR TITLE
fix: register API explorer services

### DIFF
--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -33,6 +33,7 @@ builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 builder.Services.AddSingleton<PluginManager>();
 builder.Services.AddSingleton<CommandExecutor>();
 builder.Services.AddSingleton<PayloadVerifier>();
+builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApiDocument();
 builder.Services.AddSingleton<IReportingContainer, ReportingContainer>();
 builder.Services.AddHostedService<ReportingService>();


### PR DESCRIPTION
## Summary
- register API explorer so endpoints can be discovered for OpenAPI generation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b3533eb880832198aa0e69e5dffb04