### PR TITLE
Use typed logger in command endpoints

### DIFF
--- a/src/TaskHub.Server/CommandEndpoints.cs
+++ b/src/TaskHub.Server/CommandEndpoints.cs
@@ -17,7 +17,7 @@ public static class CommandEndpoints
     {
         app.MapGet("/commands/available", (PluginManager manager) => manager.GetCommandInfos()).Produces<IEnumerable<CommandInfo>>();
 
-        app.MapPost("/commands", (CommandChainRequest request, IBackgroundJobClient client, PayloadVerifier verifier, HttpContext context, ILogger logger, CommandExecutor executor) =>
+        app.MapPost("/commands", (CommandChainRequest request, IBackgroundJobClient client, PayloadVerifier verifier, HttpContext context, ILogger<CommandEndpoints> logger, CommandExecutor executor) =>
         {
             if (!verifier.Verify(request.Payload, request.Signature))
             {
@@ -39,7 +39,7 @@ public static class CommandEndpoints
             return Results.Ok(new EnqueuedCommandResult(jobId, Array.Empty<ExecutedCommandResult>(), enqueueTime));
         }).Produces<EnqueuedCommandResult>();
 
-        app.MapPost("/commands/recurring", (RecurringCommandChainRequest request, IBackgroundJobClient client, PayloadVerifier verifier, HttpContext context, ILogger logger, CommandExecutor executor) =>
+        app.MapPost("/commands/recurring", (RecurringCommandChainRequest request, IBackgroundJobClient client, PayloadVerifier verifier, HttpContext context, ILogger<CommandEndpoints> logger, CommandExecutor executor) =>
         {
             if (!verifier.Verify(request.Payload, request.Signature))
             {


### PR DESCRIPTION
## Summary
- fix missing logger registration by using `ILogger<CommandEndpoints>` in mapped command endpoints

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b360cb06dc8321b04e773fcabfc9aa