### PR TITLE
Add recurring loaded modules report command

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -89,6 +89,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiskSpaceHandler", "plugins
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiskSpaceHandler.Tests", "tests/DiskSpaceHandler.Tests/DiskSpaceHandler.Tests.csproj", "{D5375916-D786-404E-B271-BCC353D520BF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppDomainServicePlugin", "plugins/services/AppDomainServicePlugin/AppDomainServicePlugin.csproj", "{7445DDC6-3258-4671-B5E6-E4980C8779FC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModuleInfoHandler", "plugins/handlers/ModuleInfoHandler/ModuleInfoHandler.csproj", "{CFD85D6E-AAB0-4496-8D46-7FE2538F6498}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModuleInfoHandler.Tests", "tests/ModuleInfoHandler.Tests/ModuleInfoHandler.Tests.csproj", "{02FDAEE1-A872-4157-B6C7-7018A1FBE188}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppDomainServicePlugin.Tests", "tests/AppDomainServicePlugin.Tests/AppDomainServicePlugin.Tests.csproj", "{A5B52B35-0158-4ED9-A981-8D6E7D957C85}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -267,6 +275,22 @@ Global
         {705DAE0E-564A-40AE-83C4-A675C5C02D56}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {705DAE0E-564A-40AE-83C4-A675C5C02D56}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {705DAE0E-564A-40AE-83C4-A675C5C02D56}.Release|Any CPU.Build.0 = Release|Any CPU
+        {7445DDC6-3258-4671-B5E6-E4980C8779FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {7445DDC6-3258-4671-B5E6-E4980C8779FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {7445DDC6-3258-4671-B5E6-E4980C8779FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {7445DDC6-3258-4671-B5E6-E4980C8779FC}.Release|Any CPU.Build.0 = Release|Any CPU
+        {CFD85D6E-AAB0-4496-8D46-7FE2538F6498}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {CFD85D6E-AAB0-4496-8D46-7FE2538F6498}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {CFD85D6E-AAB0-4496-8D46-7FE2538F6498}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {CFD85D6E-AAB0-4496-8D46-7FE2538F6498}.Release|Any CPU.Build.0 = Release|Any CPU
+        {02FDAEE1-A872-4157-B6C7-7018A1FBE188}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {02FDAEE1-A872-4157-B6C7-7018A1FBE188}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {02FDAEE1-A872-4157-B6C7-7018A1FBE188}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {02FDAEE1-A872-4157-B6C7-7018A1FBE188}.Release|Any CPU.Build.0 = Release|Any CPU
+        {A5B52B35-0158-4ED9-A981-8D6E7D957C85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {A5B52B35-0158-4ED9-A981-8D6E7D957C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {A5B52B35-0158-4ED9-A981-8D6E7D957C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {A5B52B35-0158-4ED9-A981-8D6E7D957C85}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/ModuleInfoHandler/ModuleInfoCommand.cs
+++ b/plugins/handlers/ModuleInfoHandler/ModuleInfoCommand.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskHub.Abstractions;
+
+namespace ModuleInfoHandler;
+
+public class ModuleInfoCommand : ICommand
+{
+    private readonly IReportingContainer? _container;
+
+    public ModuleInfoCommand(IReportingContainer? container)
+    {
+        _container = container;
+    }
+
+    public Task<OperationResult> ExecuteAsync(IServicePlugin service, CancellationToken cancellationToken)
+    {
+        var domain = (AppDomain)service.GetService();
+        var modules = domain.GetAssemblies()
+            .Select(a => new { Name = a.GetName().Name, Version = a.GetName().Version?.ToString() })
+            .ToArray();
+        var element = JsonSerializer.SerializeToElement(modules);
+        _container?.AddReport("loaded-modules", element);
+        return Task.FromResult(new OperationResult(element, "success"));
+    }
+}
+

--- a/plugins/handlers/ModuleInfoHandler/ModuleInfoCommandHandler.cs
+++ b/plugins/handlers/ModuleInfoHandler/ModuleInfoCommandHandler.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using Hangfire;
+using Microsoft.Extensions.DependencyInjection;
+using TaskHub.Abstractions;
+using TaskHub.Server;
+
+namespace ModuleInfoHandler;
+
+public class ModuleInfoCommandHandler : CommandHandlerBase, ICommandHandler<ModuleInfoCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[] { "loaded-modules" };
+    public override string ServiceName => "appdomain";
+    private IReportingContainer? _reporting;
+
+    ModuleInfoCommand ICommandHandler<ModuleInfoCommand>.Create(JsonElement payload)
+    {
+        return new ModuleInfoCommand(_reporting);
+    }
+
+    public override ICommand Create(JsonElement payload) =>
+        ((ICommandHandler<ModuleInfoCommand>)this).Create(payload);
+
+    public override void OnLoaded(IServiceProvider services)
+    {
+        _reporting = (IReportingContainer?)services.GetService(typeof(IReportingContainer));
+        var recurringJobs = services.GetRequiredService<IRecurringJobManager>();
+        var payload = JsonSerializer.Deserialize<JsonElement>("{}");
+        recurringJobs.AddOrUpdate<CommandExecutor>(
+            "loaded-modules",
+            exec => exec.Execute("loaded-modules", payload, CancellationToken.None),
+            "0 * * * *");
+    }
+}
+

--- a/plugins/handlers/ModuleInfoHandler/ModuleInfoHandler.csproj
+++ b/plugins/handlers/ModuleInfoHandler/ModuleInfoHandler.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Server\\TaskHub.Server.csproj" />
+    <ProjectReference Include="..\\..\\services\\AppDomainServicePlugin\\AppDomainServicePlugin.csproj" />
+  </ItemGroup>
+</Project>

--- a/plugins/handlers/ModuleInfoHandler/ModuleInfoRequest.cs
+++ b/plugins/handlers/ModuleInfoHandler/ModuleInfoRequest.cs
@@ -1,0 +1,4 @@
+namespace ModuleInfoHandler;
+
+public record ModuleInfoRequest();
+

--- a/plugins/services/AppDomainServicePlugin/AppDomainService.cs
+++ b/plugins/services/AppDomainServicePlugin/AppDomainService.cs
@@ -1,0 +1,12 @@
+using System;
+using TaskHub.Abstractions;
+
+namespace AppDomainServicePlugin;
+
+public class AppDomainServicePlugin : IServicePlugin
+{
+    public string Name => "appdomain";
+
+    public object GetService() => AppDomain.CurrentDomain;
+}
+

--- a/plugins/services/AppDomainServicePlugin/AppDomainServicePlugin.csproj
+++ b/plugins/services/AppDomainServicePlugin/AppDomainServicePlugin.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/AppDomainServicePlugin.Tests/AppDomainServicePlugin.Tests.csproj
+++ b/tests/AppDomainServicePlugin.Tests/AppDomainServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\AppDomainServicePlugin\\AppDomainServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/AppDomainServicePlugin.Tests/AppDomainServicePluginTests.cs
+++ b/tests/AppDomainServicePlugin.Tests/AppDomainServicePluginTests.cs
@@ -1,0 +1,17 @@
+using System;
+using AppDomainServicePlugin;
+using Xunit;
+
+namespace AppDomainServicePlugin.Tests;
+
+public class AppDomainServicePluginTests
+{
+    [Fact]
+    public void NameIsAppDomainAndReturnsCurrentDomain()
+    {
+        var plugin = new AppDomainServicePlugin();
+        Assert.Equal("appdomain", plugin.Name);
+        Assert.IsType<AppDomain>(plugin.GetService());
+    }
+}
+

--- a/tests/ModuleInfoHandler.Tests/ModuleInfoCommandHandlerTests.cs
+++ b/tests/ModuleInfoHandler.Tests/ModuleInfoCommandHandlerTests.cs
@@ -1,0 +1,16 @@
+using ModuleInfoHandler;
+using Xunit;
+
+namespace ModuleInfoHandler.Tests;
+
+public class ModuleInfoCommandHandlerTests
+{
+    [Fact]
+    public void CommandsIncludeExpectedValues()
+    {
+        var handler = new ModuleInfoCommandHandler();
+        Assert.Contains("loaded-modules", handler.Commands);
+        Assert.Equal("appdomain", handler.ServiceName);
+    }
+}
+

--- a/tests/ModuleInfoHandler.Tests/ModuleInfoHandler.Tests.csproj
+++ b/tests/ModuleInfoHandler.Tests/ModuleInfoHandler.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\ModuleInfoHandler\\ModuleInfoHandler.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add AppDomain service plugin exposing current domain
- introduce ModuleInfo command handler reporting loaded modules and versions hourly
- cover new plugin and handler with basic tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbb3395548321a61dd122b5f43db1