### PR TITLE
Add IPC service plugin

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -97,6 +97,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModuleInfoHandler.Tests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppDomainServicePlugin.Tests", "tests/AppDomainServicePlugin.Tests/AppDomainServicePlugin.Tests.csproj", "{A5B52B35-0158-4ED9-A981-8D6E7D957C85}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IpcServicePlugin", "plugins/services/IpcServicePlugin/IpcServicePlugin.csproj", "{3D507DA9-9A4B-4FEB-92B2-FFA17E6CAC27}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IpcServicePlugin.Tests", "tests/IpcServicePlugin.Tests/IpcServicePlugin.Tests.csproj", "{D3548AE2-B7A7-4426-8E86-1EAD03B6E166}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -291,6 +295,14 @@ Global
         {A5B52B35-0158-4ED9-A981-8D6E7D957C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {A5B52B35-0158-4ED9-A981-8D6E7D957C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {A5B52B35-0158-4ED9-A981-8D6E7D957C85}.Release|Any CPU.Build.0 = Release|Any CPU
+        {3D507DA9-9A4B-4FEB-92B2-FFA17E6CAC27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3D507DA9-9A4B-4FEB-92B2-FFA17E6CAC27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3D507DA9-9A4B-4FEB-92B2-FFA17E6CAC27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3D507DA9-9A4B-4FEB-92B2-FFA17E6CAC27}.Release|Any CPU.Build.0 = Release|Any CPU
+        {D3548AE2-B7A7-4426-8E86-1EAD03B6E166}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {D3548AE2-B7A7-4426-8E86-1EAD03B6E166}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {D3548AE2-B7A7-4426-8E86-1EAD03B6E166}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {D3548AE2-B7A7-4426-8E86-1EAD03B6E166}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/services/IpcServicePlugin/IpcService.cs
+++ b/plugins/services/IpcServicePlugin/IpcService.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+
+namespace IpcServicePlugin;
+
+public class IpcServicePlugin : IServicePlugin
+{
+    private readonly ILogger<IpcServicePlugin> _logger;
+
+    public IpcServicePlugin(ILogger<IpcServicePlugin> logger)
+    {
+        _logger = logger;
+    }
+
+    public string Name => "ipc";
+
+    public object GetService() => new IpcClient(_logger);
+}
+
+public class IpcClient
+{
+    private readonly ILogger _logger;
+
+    public IpcClient(ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<string> SendAsync(string pipeName, string message, CancellationToken cancellationToken = default)
+    {
+        using var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+        await client.ConnectAsync(cancellationToken);
+        using var writer = new StreamWriter(client) { AutoFlush = true };
+        using var reader = new StreamReader(client);
+        await writer.WriteLineAsync(message);
+        var response = await reader.ReadLineAsync();
+        _logger.LogInformation("Sent IPC message to {Pipe}", pipeName);
+        return response ?? string.Empty;
+    }
+}
+

--- a/plugins/services/IpcServicePlugin/IpcServicePlugin.csproj
+++ b/plugins/services/IpcServicePlugin/IpcServicePlugin.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/tests/IpcServicePlugin.Tests/IpcServicePlugin.Tests.csproj
+++ b/tests/IpcServicePlugin.Tests/IpcServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\IpcServicePlugin\\IpcServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/IpcServicePlugin.Tests/IpcServicePluginTests.cs
+++ b/tests/IpcServicePlugin.Tests/IpcServicePluginTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using IpcServicePlugin;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace IpcServicePlugin.Tests;
+
+public class IpcServicePluginTests
+{
+    [Fact]
+    public void NameIsIpc()
+    {
+        var plugin = new IpcServicePlugin(NullLogger<IpcServicePlugin>.Instance);
+        Assert.Equal("ipc", plugin.Name);
+    }
+
+    [Fact]
+    public async Task CanSendMessage()
+    {
+        var plugin = new IpcServicePlugin(NullLogger<IpcServicePlugin>.Instance);
+        var client = (IpcClient)plugin.GetService();
+        var pipeName = Guid.NewGuid().ToString();
+
+        using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut, 1, PipeTransmissionMode.Byte, PipeOptions.Asynchronous);
+
+        var serverTask = Task.Run(async () =>
+        {
+            await server.WaitForConnectionAsync();
+            using var reader = new StreamReader(server);
+            using var writer = new StreamWriter(server) { AutoFlush = true };
+            var message = await reader.ReadLineAsync();
+            await writer.WriteLineAsync(message?.ToUpperInvariant());
+        });
+
+        var response = await client.SendAsync(pipeName, "hello", CancellationToken.None);
+        Assert.Equal("HELLO", response);
+        await serverTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add IpcServicePlugin to send messages over named pipes
- wire plugin into solution and supply unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde052c64083219c474f15e0c503d5