### PR TITLE
feat: add job log storage and streaming

### DIFF
--- a/src/TaskHub.Abstractions/Interfaces/ILogPublisher.cs
+++ b/src/TaskHub.Abstractions/Interfaces/ILogPublisher.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace TaskHub.Abstractions;
+
+/// <summary>
+/// Publishes log messages produced by running jobs.
+/// </summary>
+public interface ILogPublisher
+{
+    /// <summary>
+    /// Publish a log message associated with a job.
+    /// </summary>
+    /// <param name="jobId">The job identifier.</param>
+    /// <param name="message">The log message.</param>
+    /// <param name="callbackConnectionId">Optional connection identifier to route the log.</param>
+    void PublishLog(string jobId, string message, string? callbackConnectionId);
+}

--- a/src/TaskHub.Server/CommandEndpoints.cs
+++ b/src/TaskHub.Server/CommandEndpoints.cs
@@ -212,6 +212,13 @@ public static class CommandEndpoints
         }).RequireAuthorization("CommandExecutor")
           .Produces<CommandStatusResult>();
 
+        app.MapGet("/commands/{id}/logs", (string id, IJobLogStore store) =>
+        {
+            var logs = store.GetLogs(id);
+            return logs is null ? Results.NotFound() : Results.Ok(logs);
+        }).RequireAuthorization("CommandExecutor")
+          .Produces<string[]>();
+
         return app;
     }
 }

--- a/src/TaskHub.Server/Logging/IJobLogStore.cs
+++ b/src/TaskHub.Server/Logging/IJobLogStore.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace TaskHub.Server;
+
+/// <summary>
+/// Stores log messages produced by jobs for later retrieval.
+/// </summary>
+public interface IJobLogStore
+{
+    /// <summary>
+    /// Append a log message for the specified job.
+    /// </summary>
+    void Append(string jobId, string message);
+
+    /// <summary>
+    /// Get the collected log messages for the specified job.
+    /// </summary>
+    IReadOnlyList<string>? GetLogs(string jobId);
+}

--- a/src/TaskHub.Server/Logging/JobLogStore.cs
+++ b/src/TaskHub.Server/Logging/JobLogStore.cs
@@ -1,0 +1,33 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace TaskHub.Server;
+
+/// <summary>
+/// In-memory implementation of <see cref="IJobLogStore"/> with bounded job retention.
+/// </summary>
+public class JobLogStore : IJobLogStore
+{
+    private readonly ConcurrentDictionary<string, List<string>> _logs = new();
+    private readonly ConcurrentQueue<string> _order = new();
+    private const int MaxJobs = 100;
+
+    public void Append(string jobId, string message)
+    {
+        var list = _logs.GetOrAdd(jobId, _ => new List<string>());
+        lock (list)
+        {
+            list.Add(message);
+        }
+        _order.Enqueue(jobId);
+        while (_order.Count > MaxJobs && _order.TryDequeue(out var oldId))
+        {
+            _logs.TryRemove(oldId, out _);
+        }
+    }
+
+    public IReadOnlyList<string>? GetLogs(string jobId)
+    {
+        return _logs.TryGetValue(jobId, out var list) ? list.AsReadOnly() : null;
+    }
+}

--- a/src/TaskHub.Server/Program.cs
+++ b/src/TaskHub.Server/Program.cs
@@ -55,6 +55,7 @@ builder.Services.AddSingleton<CommandExecutor>();
 builder.Services.AddSingleton<PayloadVerifier>();
 builder.Services.AddSingleton<ScriptsRepository>();
 builder.Services.AddSingleton<ScriptSignatureVerifier>();
+builder.Services.AddSingleton<IJobLogStore, JobLogStore>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApiDocument();
 builder.Services.AddSingleton<IReportingContainer, ReportingContainer>();
@@ -112,6 +113,7 @@ if (string.Equals(jobHandlingMode, "WebSocket", StringComparison.OrdinalIgnoreCa
 {
     builder.Services.AddSingleton<WebSocketJobService>();
     builder.Services.AddSingleton<IResultPublisher>(sp => sp.GetRequiredService<WebSocketJobService>());
+    builder.Services.AddSingleton<ILogPublisher>(sp => sp.GetRequiredService<WebSocketJobService>());
     builder.Services.AddHostedService(sp => sp.GetRequiredService<WebSocketJobService>());
 }
 

--- a/src/TaskHub.Server/WebSocketJobService.cs
+++ b/src/TaskHub.Server/WebSocketJobService.cs
@@ -13,7 +13,7 @@ using TaskHub.Abstractions;
 
 namespace TaskHub.Server;
 
-public class WebSocketJobService : BackgroundService, IResultPublisher
+public class WebSocketJobService : BackgroundService, IResultPublisher, ILogPublisher
 {
     private readonly IConfiguration _configuration;
     private readonly ILogger<WebSocketJobService> _logger;
@@ -42,6 +42,19 @@ public class WebSocketJobService : BackgroundService, IResultPublisher
         };
         var json = JsonSerializer.Serialize(envelope);
         await _sendQueue.Writer.WriteAsync(json, token);
+    }
+
+    public void PublishLog(string jobId, string message, string? callbackConnectionId)
+    {
+        var envelope = new
+        {
+            type = "log",
+            jobId,
+            connectionId = callbackConnectionId,
+            message
+        };
+        var json = JsonSerializer.Serialize(envelope);
+        _sendQueue.Writer.TryWrite(json);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/tests/TaskHub.Server.Tests/CommandLogsTests.cs
+++ b/tests/TaskHub.Server.Tests/CommandLogsTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Hangfire;
+using Hangfire.MemoryStorage;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Text.Encodings.Web;
+using System.Security.Claims;
+using TaskHub.Abstractions;
+using TaskHub.Server;
+using Xunit;
+
+namespace TaskHub.Server.Tests;
+
+public class CommandLogsTests
+{
+    private TestServer CreateServer()
+    {
+        var builder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddLogging();
+                services.AddRouting();
+                services.AddAuthentication("Test")
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", _ => { });
+                var config = new ConfigurationBuilder().Build();
+                services.AddSingleton<IConfiguration>(config);
+                services.AddAuthorization(options =>
+                {
+                    options.AddPolicy("CommandExecutor", p => p.RequireRole("CommandExecutor"));
+                });
+                services.AddSingleton<IBackgroundJobClient>(new BackgroundJobClient(new MemoryStorage()));
+                services.AddSingleton<PluginManager>(new PluginManager(new ServiceCollection().BuildServiceProvider()));
+                services.AddSingleton<IJobLogStore, JobLogStore>();
+                services.AddSingleton<CommandExecutor>(sp => new CommandExecutor(sp.GetRequiredService<PluginManager>(), Array.Empty<IResultPublisher>(), NullLoggerFactory.Instance));
+                services.AddSingleton<PayloadVerifier>(sp => new PayloadVerifier(config));
+            })
+            .Configure(app =>
+            {
+                app.UseRouting();
+                app.UseAuthentication();
+                app.UseAuthorization();
+                app.UseEndpoints(e =>
+                {
+                    e.MapCommandEndpoints();
+                });
+            });
+        return new TestServer(builder);
+    }
+
+    [Fact]
+    public async Task GetLogs_ReturnsStoredLogs()
+    {
+        using var server = CreateServer();
+        var store = server.Services.GetRequiredService<IJobLogStore>();
+        store.Append("job1", "hello");
+        var client = server.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Get, "/commands/job1/logs");
+        req.Headers.Add("Test-Auth", "1");
+        req.Headers.Add("Test-Role", "CommandExecutor");
+        var res = await client.SendAsync(req);
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        var logs = await res.Content.ReadFromJsonAsync<string[]>();
+        Assert.Contains("hello", logs);
+    }
+}
+
+internal class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, Microsoft.Extensions.Logging.ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+        : base(options, logger, encoder, clock) { }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.ContainsKey("Test-Auth"))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Missing"));
+        }
+        var claims = new List<Claim> { new Claim(ClaimTypes.Name, "test") };
+        if (Request.Headers.TryGetValue("Test-Role", out var roles))
+        {
+            foreach (var role in roles.ToString().Split(',', StringSplitOptions.RemoveEmptyEntries))
+            {
+                claims.Add(new Claim(ClaimTypes.Role, role));
+            }
+        }
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/TaskHub.Server.Tests/JobConsoleLoggerTests.cs
+++ b/tests/TaskHub.Server.Tests/JobConsoleLoggerTests.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using TaskHub.Server;
+using TaskHub.Abstractions;
+using Xunit;
+
+namespace TaskHub.Server.Tests;
+
+public class JobConsoleLoggerTests
+{
+    [Fact]
+    public void Log_AppendsToStore()
+    {
+        var store = new JobLogStore();
+        var logger = new JobConsoleLogger(NullLogger.Instance, null, "cmd", "job1", store, Array.Empty<ILogPublisher>(), _ => null);
+        logger.LogInformation("hello");
+        var logs = store.GetLogs("job1");
+        Assert.Single(logs!);
+        Assert.Equal("cmd hello", logs![0]);
+    }
+}


### PR DESCRIPTION
## Summary
- store job output using a new in-memory JobLogStore
- expose job logs via `/commands/{id}/logs` and stream logs over websockets
- wire up WebSocketJobService and logging helpers to publish log lines

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cb9ad0008321bc1703cebd596b64