### PR TITLE
Add Windows Event Log service plugin

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -101,6 +101,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IpcServicePlugin", "plugins
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IpcServicePlugin.Tests", "tests/IpcServicePlugin.Tests/IpcServicePlugin.Tests.csproj", "{D3548AE2-B7A7-4426-8E86-1EAD03B6E166}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventLogServicePlugin", "plugins/services/EventLogServicePlugin/EventLogServicePlugin.csproj", "{B69B1809-F29C-4C70-86BF-9724E416831F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventLogServicePlugin.Tests", "tests/EventLogServicePlugin.Tests/EventLogServicePlugin.Tests.csproj", "{BA260BA3-3CDE-4093-B084-2FF498D33908}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -303,6 +307,14 @@ Global
         {D3548AE2-B7A7-4426-8E86-1EAD03B6E166}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {D3548AE2-B7A7-4426-8E86-1EAD03B6E166}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {D3548AE2-B7A7-4426-8E86-1EAD03B6E166}.Release|Any CPU.Build.0 = Release|Any CPU
+        {B69B1809-F29C-4C70-86BF-9724E416831F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B69B1809-F29C-4C70-86BF-9724E416831F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B69B1809-F29C-4C70-86BF-9724E416831F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {B69B1809-F29C-4C70-86BF-9724E416831F}.Release|Any CPU.Build.0 = Release|Any CPU
+        {BA260BA3-3CDE-4093-B084-2FF498D33908}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {BA260BA3-3CDE-4093-B084-2FF498D33908}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {BA260BA3-3CDE-4093-B084-2FF498D33908}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {BA260BA3-3CDE-4093-B084-2FF498D33908}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/services/EventLogServicePlugin/EventLogService.cs
+++ b/plugins/services/EventLogServicePlugin/EventLogService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace EventLogServicePlugin;
+
+public class EventLogServicePlugin : IServicePlugin
+{
+    public string Name => "eventlog";
+
+    public object GetService() => new EventLogService();
+
+    public class EventLogService
+    {
+        public OperationResult Write(string source, string message, string logName = "Application", string entryType = "Information")
+        {
+            try
+            {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return new OperationResult(null, "EventLog is only supported on Windows");
+                }
+
+                if (!EventLog.SourceExists(source))
+                {
+                    EventLog.CreateEventSource(source, logName);
+                }
+
+                if (!Enum.TryParse<EventLogEntryType>(entryType, true, out var type))
+                {
+                    type = EventLogEntryType.Information;
+                }
+
+                EventLog.WriteEntry(source, message, type);
+                return new OperationResult(JsonSerializer.SerializeToElement(message), "success");
+            }
+            catch (Exception ex)
+            {
+                return new OperationResult(null, $"Failed to write event: {ex.Message}");
+            }
+        }
+    }
+}

--- a/plugins/services/EventLogServicePlugin/EventLogServicePlugin.csproj
+++ b/plugins/services/EventLogServicePlugin/EventLogServicePlugin.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/EventLogServicePlugin.Tests/EventLogServicePlugin.Tests.csproj
+++ b/tests/EventLogServicePlugin.Tests/EventLogServicePlugin.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\services\\EventLogServicePlugin\\EventLogServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/EventLogServicePlugin.Tests/EventLogServicePluginTests.cs
+++ b/tests/EventLogServicePlugin.Tests/EventLogServicePluginTests.cs
@@ -1,0 +1,27 @@
+using EventLogServicePlugin;
+using TaskHub.Abstractions;
+using Xunit;
+
+namespace EventLogServicePlugin.Tests;
+
+public class EventLogServicePluginTests
+{
+    [Fact]
+    public void NameIsEventLog()
+    {
+        var plugin = new EventLogServicePlugin();
+        Assert.Equal("eventlog", plugin.Name);
+    }
+
+    [Fact]
+    public void WriteOnUnsupportedPlatformReturnsError()
+    {
+        dynamic service = new EventLogServicePlugin().GetService();
+        OperationResult result = service.Write("TaskHub", "test message");
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+        {
+            Assert.Null(result.Payload);
+            Assert.Contains("EventLog", result.Result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add EventLog service plugin for writing to Windows Event Log
- include basic tests validating plugin name and platform error handling
- register plugin and tests in solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5df3f5074832188d0c71164b25d23