### PR TITLE
Add EventLog read support with optional XPath filters

### DIFF
--- a/tests/EventLogServicePlugin.Tests/EventLogServicePluginTests.cs
+++ b/tests/EventLogServicePlugin.Tests/EventLogServicePluginTests.cs
@@ -24,4 +24,28 @@ public class EventLogServicePluginTests
             Assert.Contains("EventLog", result.Result);
         }
     }
+
+    [Fact]
+    public void ReadOnUnsupportedPlatformReturnsError()
+    {
+        dynamic service = new EventLogServicePlugin().GetService();
+        OperationResult result = service.Read("Application");
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+        {
+            Assert.Null(result.Payload);
+            Assert.Contains("EventLog", result.Result);
+        }
+    }
+
+    [Fact]
+    public void ReadWithXPathOnUnsupportedPlatformReturnsError()
+    {
+        dynamic service = new EventLogServicePlugin().GetService();
+        OperationResult result = service.Read("Application", "*[System/Level=2]");
+        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+        {
+            Assert.Null(result.Payload);
+            Assert.Contains("EventLog", result.Result);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- extend EventLog service to read logs with optional XPath filtering
- test read behavior on non-Windows platforms

## Testing
- `dotnet test tests/EventLogServicePlugin.Tests/EventLogServicePlugin.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e2a7511483219da73b80b7dfee1f