### PR TITLE
Add PetStore service and handler

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -105,6 +105,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventLogServicePlugin", "pl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventLogServicePlugin.Tests", "tests/EventLogServicePlugin.Tests/EventLogServicePlugin.Tests.csproj", "{BA260BA3-3CDE-4093-B084-2FF498D33908}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetStoreServicePlugin", "plugins/services/PetStoreServicePlugin/PetStoreServicePlugin.csproj", "{D04D0DB8-DFFF-4E0C-A84C-8906D7A40C0D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetStoreHandler", "plugins/handlers/PetStoreHandler/PetStoreHandler.csproj", "{B666DCA7-BAF3-4356-A803-3F9C5C94303F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetStoreHandler.Tests", "tests/PetStoreHandler.Tests/PetStoreHandler.Tests.csproj", "{7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -315,6 +321,18 @@ Global
         {BA260BA3-3CDE-4093-B084-2FF498D33908}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {BA260BA3-3CDE-4093-B084-2FF498D33908}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {BA260BA3-3CDE-4093-B084-2FF498D33908}.Release|Any CPU.Build.0 = Release|Any CPU
+        {D04D0DB8-DFFF-4E0C-A84C-8906D7A40C0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {D04D0DB8-DFFF-4E0C-A84C-8906D7A40C0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {D04D0DB8-DFFF-4E0C-A84C-8906D7A40C0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {D04D0DB8-DFFF-4E0C-A84C-8906D7A40C0D}.Release|Any CPU.Build.0 = Release|Any CPU
+        {B666DCA7-BAF3-4356-A803-3F9C5C94303F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {B666DCA7-BAF3-4356-A803-3F9C5C94303F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {B666DCA7-BAF3-4356-A803-3F9C5C94303F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {B666DCA7-BAF3-4356-A803-3F9C5C94303F}.Release|Any CPU.Build.0 = Release|Any CPU
+        {7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/PetStoreHandler/GetPetCommand.cs
+++ b/plugins/handlers/PetStoreHandler/GetPetCommand.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using PetStoreServicePlugin;
+
+namespace PetStoreHandler;
+
+public class GetPetCommand : ICommand
+{
+    public GetPetCommand(GetPetRequest request)
+    {
+        Request = request;
+    }
+
+    public GetPetRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (PetStoreClient)service.GetService();
+        var pet = await client.GetPetAsync(Request.Id, cancellationToken);
+        var element = JsonSerializer.SerializeToElement(pet);
+        var status = pet != null ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/PetStoreHandler/GetPetCommandHandler.cs
+++ b/plugins/handlers/PetStoreHandler/GetPetCommandHandler.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace PetStoreHandler;
+
+public class GetPetCommandHandler : CommandHandlerBase, ICommandHandler<GetPetCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[] { "pet-get" };
+    public override string ServiceName => "petstore";
+
+    GetPetCommand ICommandHandler<GetPetCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<GetPetRequest>(payload.GetRawText()) ?? new GetPetRequest();
+        return new GetPetCommand(request);
+    }
+
+    public override ICommand Create(JsonElement payload) => ((ICommandHandler<GetPetCommand>)this).Create(payload);
+}

--- a/plugins/handlers/PetStoreHandler/GetPetRequest.cs
+++ b/plugins/handlers/PetStoreHandler/GetPetRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace PetStoreHandler;
+
+public class GetPetRequest
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+}

--- a/plugins/handlers/PetStoreHandler/PetStoreHandler.csproj
+++ b/plugins/handlers/PetStoreHandler/PetStoreHandler.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <ProjectReference Include="..\\..\\services\\PetStoreServicePlugin\\PetStoreServicePlugin.csproj" />
+  </ItemGroup>
+</Project>

--- a/plugins/services/PetStoreServicePlugin/Pet.cs
+++ b/plugins/services/PetStoreServicePlugin/Pet.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PetStoreServicePlugin;
+
+public class Pet
+{
+    [JsonPropertyName("id")] public long? Id { get; set; }
+    [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("photoUrls")] public List<string> PhotoUrls { get; set; } = new();
+    [JsonPropertyName("status")] public string? Status { get; set; }
+}

--- a/plugins/services/PetStoreServicePlugin/PetStoreClient.cs
+++ b/plugins/services/PetStoreServicePlugin/PetStoreClient.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PetStoreServicePlugin;
+
+/// <summary>
+/// Simple client for the Swagger Petstore API.
+/// Swagger spec: https://petstore.swagger.io/v2/swagger.json
+/// </summary>
+public class PetStoreClient
+{
+    private readonly HttpClient _http;
+
+    public PetStoreClient(HttpClient http)
+    {
+        _http = http;
+        if (_http.BaseAddress == null)
+        {
+            _http.BaseAddress = new Uri("https://petstore.swagger.io/v2/");
+        }
+    }
+
+    public async Task<Pet?> GetPetAsync(long id, CancellationToken cancellationToken = default)
+    {
+        var response = await _http.GetAsync($"pet/{id}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<Pet>(stream, cancellationToken: cancellationToken);
+    }
+}

--- a/plugins/services/PetStoreServicePlugin/PetStoreServicePlugin.cs
+++ b/plugins/services/PetStoreServicePlugin/PetStoreServicePlugin.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using TaskHub.Abstractions;
+
+namespace PetStoreServicePlugin;
+
+public class PetStoreServicePlugin : IServicePlugin, IDisposable
+{
+    private readonly ServiceProvider _provider;
+    private readonly PetStoreClient _client;
+
+    public PetStoreServicePlugin()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient<PetStoreClient>();
+        _provider = services.BuildServiceProvider();
+        _client = _provider.GetRequiredService<PetStoreClient>();
+    }
+
+    public string Name => "petstore";
+
+    public object GetService() => _client;
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/plugins/services/PetStoreServicePlugin/PetStoreServicePlugin.csproj
+++ b/plugins/services/PetStoreServicePlugin/PetStoreServicePlugin.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/tests/PetStoreHandler.Tests/PetStoreCommandHandlerTests.cs
+++ b/tests/PetStoreHandler.Tests/PetStoreCommandHandlerTests.cs
@@ -1,0 +1,13 @@
+using PetStoreHandler;
+using Xunit;
+
+public class PetStoreCommandHandlerTests
+{
+    [Fact]
+    public void ShouldExposeCommandAndService()
+    {
+        var handler = new GetPetCommandHandler();
+        Assert.Contains("pet-get", handler.Commands);
+        Assert.Equal("petstore", handler.ServiceName);
+    }
+}

--- a/tests/PetStoreHandler.Tests/PetStoreHandler.Tests.csproj
+++ b/tests/PetStoreHandler.Tests/PetStoreHandler.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\PetStoreHandler\\PetStoreHandler.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add PetStoreServicePlugin providing a Petstore API client
- add PetStore handler to fetch pet info using service
- remove local swagger spec and let client configure its own base URL
- use `HttpClientFactory` to construct `PetStoreClient`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c670061c488321b3a8eca91fddeea2