### PR TITLE
Add FakeRest service and handler

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -111,6 +111,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetStoreHandler", "plugins/
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PetStoreHandler.Tests", "tests/PetStoreHandler.Tests/PetStoreHandler.Tests.csproj", "{7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FakeRestServicePlugin", "plugins/services/FakeRestServicePlugin/FakeRestServicePlugin.csproj", "{80C8250F-5BC1-4A2F-AC82-406DD3328C4F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FakeRestHandler", "plugins/handlers/FakeRestHandler/FakeRestHandler.csproj", "{405D337B-91A9-422F-B913-4A7C1C892B93}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FakeRestHandler.Tests", "tests/FakeRestHandler.Tests/FakeRestHandler.Tests.csproj", "{DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -333,6 +339,18 @@ Global
         {7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {7C2EA8AC-BE81-46B3-9B0E-C6CFC4F4143D}.Release|Any CPU.Build.0 = Release|Any CPU
+        {80C8250F-5BC1-4A2F-AC82-406DD3328C4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {80C8250F-5BC1-4A2F-AC82-406DD3328C4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {80C8250F-5BC1-4A2F-AC82-406DD3328C4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {80C8250F-5BC1-4A2F-AC82-406DD3328C4F}.Release|Any CPU.Build.0 = Release|Any CPU
+        {405D337B-91A9-422F-B913-4A7C1C892B93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {405D337B-91A9-422F-B913-4A7C1C892B93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {405D337B-91A9-422F-B913-4A7C1C892B93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {405D337B-91A9-422F-B913-4A7C1C892B93}.Release|Any CPU.Build.0 = Release|Any CPU
+        {DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/FakeRestHandler/CreateBookCommand.cs
+++ b/plugins/handlers/FakeRestHandler/CreateBookCommand.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using FakeRestServicePlugin;
+
+namespace FakeRestHandler;
+
+public class CreateBookCommand : ICommand
+{
+    public CreateBookCommand(Book book)
+    {
+        Book = book;
+    }
+
+    public Book Book { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (FakeRestClient)service.GetService();
+        var created = await client.CreateBookAsync(Book, cancellationToken);
+        var element = JsonSerializer.SerializeToElement(created);
+        var status = created != null ? "success" : "error";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/FakeRestHandler/CreateBookCommandHandler.cs
+++ b/plugins/handlers/FakeRestHandler/CreateBookCommandHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+using FakeRestServicePlugin;
+
+namespace FakeRestHandler;
+
+public class CreateBookCommandHandler : CommandHandlerBase, ICommandHandler<CreateBookCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[] { "book-create" };
+    public override string ServiceName => "fakerest";
+
+    CreateBookCommand ICommandHandler<CreateBookCommand>.Create(JsonElement payload)
+    {
+        var book = JsonSerializer.Deserialize<Book>(payload.GetRawText()) ?? new Book();
+        return new CreateBookCommand(book);
+    }
+
+    public override ICommand Create(JsonElement payload) => ((ICommandHandler<CreateBookCommand>)this).Create(payload);
+
+    public override void OnLoaded(IServiceProvider services) { }
+}

--- a/plugins/handlers/FakeRestHandler/DeleteBookCommand.cs
+++ b/plugins/handlers/FakeRestHandler/DeleteBookCommand.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using FakeRestServicePlugin;
+
+namespace FakeRestHandler;
+
+public class DeleteBookCommand : ICommand
+{
+    public DeleteBookCommand(GetBookRequest request)
+    {
+        Request = request;
+    }
+
+    public GetBookRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (FakeRestClient)service.GetService();
+        var success = await client.DeleteBookAsync(Request.Id, cancellationToken);
+        var element = JsonSerializer.SerializeToElement(success);
+        var status = success ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/FakeRestHandler/DeleteBookCommandHandler.cs
+++ b/plugins/handlers/FakeRestHandler/DeleteBookCommandHandler.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace FakeRestHandler;
+
+public class DeleteBookCommandHandler : CommandHandlerBase, ICommandHandler<DeleteBookCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[] { "book-delete" };
+    public override string ServiceName => "fakerest";
+
+    DeleteBookCommand ICommandHandler<DeleteBookCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<GetBookRequest>(payload.GetRawText()) ?? new GetBookRequest();
+        return new DeleteBookCommand(request);
+    }
+
+    public override ICommand Create(JsonElement payload) => ((ICommandHandler<DeleteBookCommand>)this).Create(payload);
+
+    public override void OnLoaded(IServiceProvider services) { }
+}

--- a/plugins/handlers/FakeRestHandler/FakeRestHandler.csproj
+++ b/plugins/handlers/FakeRestHandler/FakeRestHandler.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <ProjectReference Include="..\\..\\services\\FakeRestServicePlugin\\FakeRestServicePlugin.csproj" />
+  </ItemGroup>
+</Project>

--- a/plugins/handlers/FakeRestHandler/GetBookCommand.cs
+++ b/plugins/handlers/FakeRestHandler/GetBookCommand.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using FakeRestServicePlugin;
+
+namespace FakeRestHandler;
+
+public class GetBookCommand : ICommand
+{
+    public GetBookCommand(GetBookRequest request)
+    {
+        Request = request;
+    }
+
+    public GetBookRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (FakeRestClient)service.GetService();
+        var book = await client.GetBookAsync(Request.Id, cancellationToken);
+        var element = JsonSerializer.SerializeToElement(book);
+        var status = book != null ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/FakeRestHandler/GetBookCommandHandler.cs
+++ b/plugins/handlers/FakeRestHandler/GetBookCommandHandler.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace FakeRestHandler;
+
+public class GetBookCommandHandler : CommandHandlerBase, ICommandHandler<GetBookCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[] { "book-get" };
+    public override string ServiceName => "fakerest";
+
+    GetBookCommand ICommandHandler<GetBookCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<GetBookRequest>(payload.GetRawText()) ?? new GetBookRequest();
+        return new GetBookCommand(request);
+    }
+
+    public override ICommand Create(JsonElement payload) => ((ICommandHandler<GetBookCommand>)this).Create(payload);
+}

--- a/plugins/handlers/FakeRestHandler/GetBookRequest.cs
+++ b/plugins/handlers/FakeRestHandler/GetBookRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace FakeRestHandler;
+
+public class GetBookRequest
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+}

--- a/plugins/handlers/FakeRestHandler/ListBooksCommand.cs
+++ b/plugins/handlers/FakeRestHandler/ListBooksCommand.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using FakeRestServicePlugin;
+
+namespace FakeRestHandler;
+
+public class ListBooksCommand : ICommand
+{
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (FakeRestClient)service.GetService();
+        var books = await client.GetBooksAsync(cancellationToken);
+        var element = JsonSerializer.SerializeToElement(books);
+        return new OperationResult(element, "success");
+    }
+}

--- a/plugins/handlers/FakeRestHandler/ListBooksCommandHandler.cs
+++ b/plugins/handlers/FakeRestHandler/ListBooksCommandHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace FakeRestHandler;
+
+public class ListBooksCommandHandler : CommandHandlerBase, ICommandHandler<ListBooksCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[] { "book-list" };
+    public override string ServiceName => "fakerest";
+
+    ListBooksCommand ICommandHandler<ListBooksCommand>.Create(JsonElement payload)
+    {
+        return new ListBooksCommand();
+    }
+
+    public override ICommand Create(JsonElement payload) => ((ICommandHandler<ListBooksCommand>)this).Create(payload);
+
+    public override void OnLoaded(IServiceProvider services) { }
+}

--- a/plugins/handlers/FakeRestHandler/UpdateBookCommand.cs
+++ b/plugins/handlers/FakeRestHandler/UpdateBookCommand.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using FakeRestServicePlugin;
+
+namespace FakeRestHandler;
+
+public class UpdateBookCommand : ICommand
+{
+    public UpdateBookCommand(Book book)
+    {
+        Book = book;
+    }
+
+    public Book Book { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (FakeRestClient)service.GetService();
+        var success = await client.UpdateBookAsync(Book.Id, Book, cancellationToken);
+        var element = JsonSerializer.SerializeToElement(success);
+        var status = success ? "success" : "error";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/FakeRestHandler/UpdateBookCommandHandler.cs
+++ b/plugins/handlers/FakeRestHandler/UpdateBookCommandHandler.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+using FakeRestServicePlugin;
+
+namespace FakeRestHandler;
+
+public class UpdateBookCommandHandler : CommandHandlerBase, ICommandHandler<UpdateBookCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[] { "book-update" };
+    public override string ServiceName => "fakerest";
+
+    UpdateBookCommand ICommandHandler<UpdateBookCommand>.Create(JsonElement payload)
+    {
+        var book = JsonSerializer.Deserialize<Book>(payload.GetRawText()) ?? new Book();
+        return new UpdateBookCommand(book);
+    }
+
+    public override ICommand Create(JsonElement payload) => ((ICommandHandler<UpdateBookCommand>)this).Create(payload);
+
+    public override void OnLoaded(IServiceProvider services) { }
+}

--- a/plugins/services/FakeRestServicePlugin/Book.cs
+++ b/plugins/services/FakeRestServicePlugin/Book.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace FakeRestServicePlugin;
+
+public class Book
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("pageCount")]
+    public int PageCount { get; set; }
+
+    [JsonPropertyName("excerpt")]
+    public string? Excerpt { get; set; }
+
+    [JsonPropertyName("publishDate")]
+    public DateTime PublishDate { get; set; }
+}

--- a/plugins/services/FakeRestServicePlugin/FakeRestClient.cs
+++ b/plugins/services/FakeRestServicePlugin/FakeRestClient.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FakeRestServicePlugin;
+
+/// <summary>
+/// Simple client for the Fake REST API.
+/// Swagger spec: https://fakerestapi.azurewebsites.net/swagger/v1/swagger.json
+/// </summary>
+public class FakeRestClient
+{
+    private readonly HttpClient _http;
+
+    public FakeRestClient(HttpClient http)
+    {
+        _http = http;
+        if (_http.BaseAddress == null)
+        {
+            _http.BaseAddress = new Uri("https://fakerestapi.azurewebsites.net/api/v1/");
+        }
+    }
+
+    public async Task<IReadOnlyList<Book>> GetBooksAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _http.GetAsync("Books", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return Array.Empty<Book>();
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var books = await JsonSerializer.DeserializeAsync<List<Book>>(stream, cancellationToken: cancellationToken);
+        return books ?? new List<Book>();
+    }
+
+    public async Task<Book?> GetBookAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var response = await _http.GetAsync($"Books/{id}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<Book>(stream, cancellationToken: cancellationToken);
+    }
+
+    public async Task<Book?> CreateBookAsync(Book book, CancellationToken cancellationToken = default)
+    {
+        var content = new StringContent(JsonSerializer.Serialize(book), Encoding.UTF8, "application/json");
+        var response = await _http.PostAsync("Books", content, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<Book>(stream, cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> UpdateBookAsync(int id, Book book, CancellationToken cancellationToken = default)
+    {
+        var content = new StringContent(JsonSerializer.Serialize(book), Encoding.UTF8, "application/json");
+        var response = await _http.PutAsync($"Books/{id}", content, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<bool> DeleteBookAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var response = await _http.DeleteAsync($"Books/{id}", cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+}

--- a/plugins/services/FakeRestServicePlugin/FakeRestServicePlugin.cs
+++ b/plugins/services/FakeRestServicePlugin/FakeRestServicePlugin.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using TaskHub.Abstractions;
+
+namespace FakeRestServicePlugin;
+
+public class FakeRestServicePlugin : IServicePlugin, IDisposable
+{
+    private readonly ServiceProvider _provider;
+    private readonly FakeRestClient _client;
+
+    public FakeRestServicePlugin()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient<FakeRestClient>();
+        _provider = services.BuildServiceProvider();
+        _client = _provider.GetRequiredService<FakeRestClient>();
+    }
+
+    public string Name => "fakerest";
+
+    public object GetService() => _client;
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/plugins/services/FakeRestServicePlugin/FakeRestServicePlugin.csproj
+++ b/plugins/services/FakeRestServicePlugin/FakeRestServicePlugin.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/tests/FakeRestHandler.Tests/FakeRestCommandHandlerTests.cs
+++ b/tests/FakeRestHandler.Tests/FakeRestCommandHandlerTests.cs
@@ -1,0 +1,45 @@
+using FakeRestHandler;
+using Xunit;
+
+public class FakeRestCommandHandlerTests
+{
+    [Fact]
+    public void GetHandlerShouldExposeCommandAndService()
+    {
+        var handler = new GetBookCommandHandler();
+        Assert.Contains("book-get", handler.Commands);
+        Assert.Equal("fakerest", handler.ServiceName);
+    }
+
+    [Fact]
+    public void ListHandlerShouldExposeCommandAndService()
+    {
+        var handler = new ListBooksCommandHandler();
+        Assert.Contains("book-list", handler.Commands);
+        Assert.Equal("fakerest", handler.ServiceName);
+    }
+
+    [Fact]
+    public void CreateHandlerShouldExposeCommandAndService()
+    {
+        var handler = new CreateBookCommandHandler();
+        Assert.Contains("book-create", handler.Commands);
+        Assert.Equal("fakerest", handler.ServiceName);
+    }
+
+    [Fact]
+    public void UpdateHandlerShouldExposeCommandAndService()
+    {
+        var handler = new UpdateBookCommandHandler();
+        Assert.Contains("book-update", handler.Commands);
+        Assert.Equal("fakerest", handler.ServiceName);
+    }
+
+    [Fact]
+    public void DeleteHandlerShouldExposeCommandAndService()
+    {
+        var handler = new DeleteBookCommandHandler();
+        Assert.Contains("book-delete", handler.Commands);
+        Assert.Equal("fakerest", handler.ServiceName);
+    }
+}

--- a/tests/FakeRestHandler.Tests/FakeRestHandler.Tests.csproj
+++ b/tests/FakeRestHandler.Tests/FakeRestHandler.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\plugins\\handlers\\FakeRestHandler\\FakeRestHandler.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- expand FakeRestClient with methods for listing, creating, updating, and deleting books
- add handlers and commands for book-list, book-create, book-update, and book-delete
- cover new handlers with unit tests for command exposure

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6743fb7d483218dec96b199efc2d9