### PR TITLE
Add Binance service plugin and handler

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -117,6 +117,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FakeRestHandler", "plugins/
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FakeRestHandler.Tests", "tests/FakeRestHandler.Tests/FakeRestHandler.Tests.csproj", "{DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BinanceServicePlugin", "plugins/services/BinanceServicePlugin/BinanceServicePlugin.csproj", "{1E6EA56D-69FE-4CD0-BFE1-C186C1BD3BFC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BinanceHandler", "plugins/handlers/BinanceHandler/BinanceHandler.csproj", "{EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -351,6 +355,14 @@ Global
         {DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {DE0C697B-A2AC-45E5-BC3B-74D9BD23FECC}.Release|Any CPU.Build.0 = Release|Any CPU
+        {1E6EA56D-69FE-4CD0-BFE1-C186C1BD3BFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {1E6EA56D-69FE-4CD0-BFE1-C186C1BD3BFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {1E6EA56D-69FE-4CD0-BFE1-C186C1BD3BFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {1E6EA56D-69FE-4CD0-BFE1-C186C1BD3BFC}.Release|Any CPU.Build.0 = Release|Any CPU
+        {EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/handlers/BinanceHandler/AcceptConvertQuoteCommand.cs
+++ b/plugins/handlers/BinanceHandler/AcceptConvertQuoteCommand.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class AcceptConvertQuoteCommand : ICommand
+{
+    public AcceptConvertQuoteCommand(AcceptConvertQuoteRequest request)
+    {
+        Request = request;
+    }
+
+    public AcceptConvertQuoteRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var result = await client.AcceptConvertQuoteAsync(Request.QuoteId, cancellationToken);
+        var element = result ?? JsonDocument.Parse("null").RootElement;
+        var status = result.HasValue ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/BinanceHandler/AcceptConvertQuoteRequest.cs
+++ b/plugins/handlers/BinanceHandler/AcceptConvertQuoteRequest.cs
@@ -1,0 +1,6 @@
+namespace BinanceHandler;
+
+public class AcceptConvertQuoteRequest
+{
+    public string QuoteId { get; set; } = string.Empty;
+}

--- a/plugins/handlers/BinanceHandler/BinanceCommandHandler.cs
+++ b/plugins/handlers/BinanceHandler/BinanceCommandHandler.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using TaskHub.Abstractions;
+
+namespace BinanceHandler;
+
+public class BinanceCommandHandler : CommandHandlerBase,
+    ICommandHandler<CallEndpointCommand>,
+    ICommandHandler<GetServerTimeCommand>,
+    ICommandHandler<GetExchangeInfoCommand>,
+    ICommandHandler<GetTickerPriceCommand>,
+    ICommandHandler<GetAveragePriceCommand>,
+    ICommandHandler<GetConvertQuoteCommand>,
+    ICommandHandler<AcceptConvertQuoteCommand>,
+    ICommandHandler<GetConvertOrderStatusCommand>,
+    ICommandHandler<GetConvertTradeFlowCommand>
+{
+    public override IReadOnlyCollection<string> Commands => new[]
+    {
+        "binance-call",
+        "binance-server-time",
+        "binance-exchange-info",
+        "binance-ticker-price",
+        "binance-avg-price",
+        "binance-convert-get-quote",
+        "binance-convert-accept-quote",
+        "binance-convert-order-status",
+        "binance-convert-trade-flow"
+    };
+
+    public override string ServiceName => "binance";
+
+    CallEndpointCommand ICommandHandler<CallEndpointCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<CallEndpointRequest>(payload.GetRawText()) ?? new CallEndpointRequest();
+        return new CallEndpointCommand(request);
+    }
+
+    GetServerTimeCommand ICommandHandler<GetServerTimeCommand>.Create(JsonElement payload)
+    {
+        return new GetServerTimeCommand();
+    }
+
+    GetExchangeInfoCommand ICommandHandler<GetExchangeInfoCommand>.Create(JsonElement payload)
+    {
+        return new GetExchangeInfoCommand();
+    }
+
+    GetTickerPriceCommand ICommandHandler<GetTickerPriceCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<GetTickerPriceRequest>(payload.GetRawText()) ?? new GetTickerPriceRequest();
+        return new GetTickerPriceCommand(request);
+    }
+
+    GetAveragePriceCommand ICommandHandler<GetAveragePriceCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<GetAveragePriceRequest>(payload.GetRawText()) ?? new GetAveragePriceRequest();
+        return new GetAveragePriceCommand(request);
+    }
+
+    GetConvertQuoteCommand ICommandHandler<GetConvertQuoteCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<GetConvertQuoteRequest>(payload.GetRawText()) ?? new GetConvertQuoteRequest();
+        return new GetConvertQuoteCommand(request);
+    }
+
+    AcceptConvertQuoteCommand ICommandHandler<AcceptConvertQuoteCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<AcceptConvertQuoteRequest>(payload.GetRawText()) ?? new AcceptConvertQuoteRequest();
+        return new AcceptConvertQuoteCommand(request);
+    }
+
+    GetConvertOrderStatusCommand ICommandHandler<GetConvertOrderStatusCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<GetConvertOrderStatusRequest>(payload.GetRawText()) ?? new GetConvertOrderStatusRequest();
+        return new GetConvertOrderStatusCommand(request);
+    }
+
+    GetConvertTradeFlowCommand ICommandHandler<GetConvertTradeFlowCommand>.Create(JsonElement payload)
+    {
+        var request = JsonSerializer.Deserialize<GetConvertTradeFlowRequest>(payload.GetRawText()) ?? new GetConvertTradeFlowRequest();
+        return new GetConvertTradeFlowCommand(request);
+    }
+
+    public override ICommand Create(JsonElement payload)
+    {
+        if (payload.ValueKind == JsonValueKind.Object)
+        {
+            if (payload.TryGetProperty("method", out _))
+            {
+                return ((ICommandHandler<CallEndpointCommand>)this).Create(payload);
+            }
+            if (payload.TryGetProperty("quoteId", out _) && !payload.TryGetProperty("orderId", out _))
+            {
+                return ((ICommandHandler<AcceptConvertQuoteCommand>)this).Create(payload);
+            }
+
+            if (payload.TryGetProperty("orderId", out _))
+            {
+                return ((ICommandHandler<GetConvertOrderStatusCommand>)this).Create(payload);
+            }
+
+            if (payload.TryGetProperty("fromAsset", out _) && payload.TryGetProperty("toAsset", out _))
+            {
+                return ((ICommandHandler<GetConvertQuoteCommand>)this).Create(payload);
+            }
+
+            if (payload.TryGetProperty("startTime", out _) || payload.TryGetProperty("endTime", out _))
+            {
+                return ((ICommandHandler<GetConvertTradeFlowCommand>)this).Create(payload);
+            }
+
+            if (payload.TryGetProperty("avg", out _))
+            {
+                return ((ICommandHandler<GetAveragePriceCommand>)this).Create(payload);
+            }
+
+            if (payload.TryGetProperty("symbol", out _))
+            {
+                return ((ICommandHandler<GetTickerPriceCommand>)this).Create(payload);
+            }
+
+            if (payload.TryGetProperty("exchangeInfo", out _))
+            {
+                return ((ICommandHandler<GetExchangeInfoCommand>)this).Create(payload);
+            }
+        }
+
+        return ((ICommandHandler<GetServerTimeCommand>)this).Create(payload);
+    }
+
+    public override void OnLoaded(IServiceProvider services) { }
+}

--- a/plugins/handlers/BinanceHandler/BinanceHandler.csproj
+++ b/plugins/handlers/BinanceHandler/BinanceHandler.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <ProjectReference Include="..\\..\\services\\BinanceServicePlugin\\BinanceServicePlugin.csproj" />
+  </ItemGroup>
+</Project>

--- a/plugins/handlers/BinanceHandler/CallEndpointCommand.cs
+++ b/plugins/handlers/BinanceHandler/CallEndpointCommand.cs
@@ -1,0 +1,30 @@
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class CallEndpointCommand : ICommand
+{
+    public CallEndpointCommand(CallEndpointRequest request)
+    {
+        Request = request;
+    }
+
+    public CallEndpointRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var method = new HttpMethod(Request.Method.ToUpperInvariant());
+        var result = await client.SendAsync(method, Request.Endpoint, Request.Query, Request.Body, cancellationToken);
+        var element = result ?? JsonDocument.Parse("{}").RootElement;
+        var status = result != null ? "success" : "error";
+        return new OperationResult(element, status);
+    }
+}
+

--- a/plugins/handlers/BinanceHandler/CallEndpointRequest.cs
+++ b/plugins/handlers/BinanceHandler/CallEndpointRequest.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace BinanceHandler;
+
+public class CallEndpointRequest
+{
+    public string Method { get; set; } = "GET";
+    public string Endpoint { get; set; } = string.Empty;
+    public Dictionary<string, string>? Query { get; set; }
+
+    public JsonElement? Body { get; set; }
+}
+

--- a/plugins/handlers/BinanceHandler/GetAveragePriceCommand.cs
+++ b/plugins/handlers/BinanceHandler/GetAveragePriceCommand.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class GetAveragePriceCommand : ICommand
+{
+    public GetAveragePriceCommand(GetAveragePriceRequest request)
+    {
+        Request = request;
+    }
+
+    public GetAveragePriceRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var price = await client.GetAveragePriceAsync(Request.Symbol, cancellationToken);
+        var element = JsonSerializer.SerializeToElement(price);
+        var status = price != null ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/BinanceHandler/GetAveragePriceRequest.cs
+++ b/plugins/handlers/BinanceHandler/GetAveragePriceRequest.cs
@@ -1,0 +1,6 @@
+namespace BinanceHandler;
+
+public class GetAveragePriceRequest
+{
+    public string Symbol { get; set; } = string.Empty;
+}

--- a/plugins/handlers/BinanceHandler/GetConvertOrderStatusCommand.cs
+++ b/plugins/handlers/BinanceHandler/GetConvertOrderStatusCommand.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class GetConvertOrderStatusCommand : ICommand
+{
+    public GetConvertOrderStatusCommand(GetConvertOrderStatusRequest request)
+    {
+        Request = request;
+    }
+
+    public GetConvertOrderStatusRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var statusResp = await client.GetConvertOrderStatusAsync(Request.OrderId, cancellationToken);
+        var element = statusResp ?? JsonDocument.Parse("null").RootElement;
+        var status = statusResp.HasValue ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/BinanceHandler/GetConvertOrderStatusRequest.cs
+++ b/plugins/handlers/BinanceHandler/GetConvertOrderStatusRequest.cs
@@ -1,0 +1,6 @@
+namespace BinanceHandler;
+
+public class GetConvertOrderStatusRequest
+{
+    public string OrderId { get; set; } = string.Empty;
+}

--- a/plugins/handlers/BinanceHandler/GetConvertQuoteCommand.cs
+++ b/plugins/handlers/BinanceHandler/GetConvertQuoteCommand.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class GetConvertQuoteCommand : ICommand
+{
+    public GetConvertQuoteCommand(GetConvertQuoteRequest request)
+    {
+        Request = request;
+    }
+
+    public GetConvertQuoteRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var quote = await client.GetConvertQuoteAsync(
+            Request.FromAsset,
+            Request.ToAsset,
+            Request.FromAmount,
+            Request.ToAmount,
+            cancellationToken);
+        var element = quote ?? JsonDocument.Parse("null").RootElement;
+        var status = quote.HasValue ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/BinanceHandler/GetConvertQuoteRequest.cs
+++ b/plugins/handlers/BinanceHandler/GetConvertQuoteRequest.cs
@@ -1,0 +1,9 @@
+namespace BinanceHandler;
+
+public class GetConvertQuoteRequest
+{
+    public string FromAsset { get; set; } = string.Empty;
+    public string ToAsset { get; set; } = string.Empty;
+    public string? FromAmount { get; set; }
+    public string? ToAmount { get; set; }
+}

--- a/plugins/handlers/BinanceHandler/GetConvertTradeFlowCommand.cs
+++ b/plugins/handlers/BinanceHandler/GetConvertTradeFlowCommand.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class GetConvertTradeFlowCommand : ICommand
+{
+    public GetConvertTradeFlowCommand(GetConvertTradeFlowRequest request)
+    {
+        Request = request;
+    }
+
+    public GetConvertTradeFlowRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var flow = await client.GetConvertTradeFlowAsync(
+            Request.StartTime,
+            Request.EndTime,
+            Request.Page,
+            Request.Limit,
+            cancellationToken);
+        var element = flow ?? JsonDocument.Parse("null").RootElement;
+        var status = flow.HasValue ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/BinanceHandler/GetConvertTradeFlowRequest.cs
+++ b/plugins/handlers/BinanceHandler/GetConvertTradeFlowRequest.cs
@@ -1,0 +1,9 @@
+namespace BinanceHandler;
+
+public class GetConvertTradeFlowRequest
+{
+    public long StartTime { get; set; }
+    public long EndTime { get; set; }
+    public int? Page { get; set; }
+    public int? Limit { get; set; }
+}

--- a/plugins/handlers/BinanceHandler/GetExchangeInfoCommand.cs
+++ b/plugins/handlers/BinanceHandler/GetExchangeInfoCommand.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class GetExchangeInfoCommand : ICommand
+{
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var info = await client.GetExchangeInfoAsync(cancellationToken);
+        var element = JsonSerializer.SerializeToElement(info);
+        var status = info != null ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/BinanceHandler/GetServerTimeCommand.cs
+++ b/plugins/handlers/BinanceHandler/GetServerTimeCommand.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class GetServerTimeCommand : ICommand
+{
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var serverTime = await client.GetServerTimeAsync(cancellationToken);
+        var element = JsonSerializer.SerializeToElement(serverTime);
+        var status = serverTime != null ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}

--- a/plugins/handlers/BinanceHandler/GetTickerPriceCommand.cs
+++ b/plugins/handlers/BinanceHandler/GetTickerPriceCommand.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using TaskHub.Abstractions;
+using BinanceServicePlugin;
+
+namespace BinanceHandler;
+
+public class GetTickerPriceCommand : ICommand
+{
+    public GetTickerPriceCommand(GetTickerPriceRequest request)
+    {
+        Request = request;
+    }
+
+    public GetTickerPriceRequest Request { get; }
+
+    public async Task<OperationResult> ExecuteAsync(IServicePlugin service, ILogger logger, CancellationToken cancellationToken)
+    {
+        var client = (BinanceClient)service.GetService();
+        var price = await client.GetTickerPriceAsync(Request.Symbol, cancellationToken);
+        var element = JsonSerializer.SerializeToElement(price);
+        var status = price != null ? "success" : "not_found";
+        return new OperationResult(element, status);
+    }
+}
+

--- a/plugins/handlers/BinanceHandler/GetTickerPriceRequest.cs
+++ b/plugins/handlers/BinanceHandler/GetTickerPriceRequest.cs
@@ -1,0 +1,12 @@
+namespace BinanceHandler;
+
+public class GetTickerPriceRequest
+{
+    public GetTickerPriceRequest(string symbol)
+    {
+        Symbol = symbol;
+    }
+
+    public string Symbol { get; }
+}
+

--- a/plugins/services/BinanceServicePlugin/AveragePrice.cs
+++ b/plugins/services/BinanceServicePlugin/AveragePrice.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace BinanceServicePlugin;
+
+public class AveragePrice
+{
+    [JsonPropertyName("mins")]
+    public int Mins { get; set; }
+
+    [JsonPropertyName("price")]
+    public string Price { get; set; } = string.Empty;
+}

--- a/plugins/services/BinanceServicePlugin/BinanceClient.cs
+++ b/plugins/services/BinanceServicePlugin/BinanceClient.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BinanceServicePlugin;
+
+/// <summary>
+/// Simple client for the Binance Spot REST API.
+/// OpenAPI spec: https://binance.github.io/binance-api-swagger/spot_api.yaml
+/// </summary>
+public class BinanceClient
+{
+    private readonly HttpClient _http;
+
+    public BinanceClient(HttpClient http)
+    {
+        _http = http;
+        if (_http.BaseAddress == null)
+        {
+            _http.BaseAddress = new Uri("https://api.binance.com/api/v3/");
+        }
+    }
+
+    /// <summary>
+    /// Gets current server time.
+    /// </summary>
+    public async Task<ServerTime?> GetServerTimeAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _http.GetAsync("time", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<ServerTime>(stream, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets basic exchange information.
+    /// </summary>
+    public async Task<ExchangeInfo?> GetExchangeInfoAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await _http.GetAsync("exchangeInfo", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<ExchangeInfo>(stream, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets current average price for a symbol.
+    /// </summary>
+    public async Task<AveragePrice?> GetAveragePriceAsync(string symbol, CancellationToken cancellationToken = default)
+    {
+        var response = await _http.GetAsync($"avgPrice?symbol={Uri.EscapeDataString(symbol)}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<AveragePrice>(stream, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets latest price for a symbol.
+    /// </summary>
+    public async Task<TickerPrice?> GetTickerPriceAsync(string symbol, CancellationToken cancellationToken = default)
+    {
+        var response = await _http.GetAsync($"ticker/price?symbol={Uri.EscapeDataString(symbol)}", cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<TickerPrice>(stream, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Requests a conversion quote.
+    /// </summary>
+    public Task<JsonElement?> GetConvertQuoteAsync(
+        string fromAsset,
+        string toAsset,
+        string? fromAmount = null,
+        string? toAmount = null,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new Dictionary<string, string>
+        {
+            ["fromAsset"] = fromAsset,
+            ["toAsset"] = toAsset
+        };
+        if (!string.IsNullOrEmpty(fromAmount)) query["fromAmount"] = fromAmount;
+        if (!string.IsNullOrEmpty(toAmount)) query["toAmount"] = toAmount;
+        return SendAsync(HttpMethod.Post, "https://api.binance.com/sapi/v1/convert/getQuote", query, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Accepts a previously returned quote.
+    /// </summary>
+    public Task<JsonElement?> AcceptConvertQuoteAsync(string quoteId, CancellationToken cancellationToken = default)
+    {
+        var query = new Dictionary<string, string>
+        {
+            ["quoteId"] = quoteId
+        };
+        return SendAsync(HttpMethod.Post, "https://api.binance.com/sapi/v1/convert/acceptQuote", query, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Retrieves status for a convert order.
+    /// </summary>
+    public Task<JsonElement?> GetConvertOrderStatusAsync(string orderId, CancellationToken cancellationToken = default)
+    {
+        var query = new Dictionary<string, string>
+        {
+            ["orderId"] = orderId
+        };
+        return SendAsync(HttpMethod.Get, "https://api.binance.com/sapi/v1/convert/orderStatus", query, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Lists convert trade history.
+    /// </summary>
+    public Task<JsonElement?> GetConvertTradeFlowAsync(
+        long startTime,
+        long endTime,
+        int? page = null,
+        int? limit = null,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new Dictionary<string, string>
+        {
+            ["startTime"] = startTime.ToString(),
+            ["endTime"] = endTime.ToString()
+        };
+        if (page.HasValue) query["page"] = page.Value.ToString();
+        if (limit.HasValue) query["limit"] = limit.Value.ToString();
+        return SendAsync(HttpMethod.Get, "https://api.binance.com/sapi/v1/convert/tradeFlow", query, null, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends a raw request to any Binance endpoint.
+    /// </summary>
+    public async Task<JsonElement?> SendAsync(
+        HttpMethod method,
+        string endpoint,
+        Dictionary<string, string>? query = null,
+        JsonElement? body = null,
+        CancellationToken cancellationToken = default)
+    {
+        var builder = new StringBuilder(endpoint);
+        if (query != null && query.Count > 0)
+        {
+            builder.Append('?');
+            var first = true;
+            foreach (var kvp in query)
+            {
+                if (!first)
+                {
+                    builder.Append('&');
+                }
+                first = false;
+                builder.Append(Uri.EscapeDataString(kvp.Key));
+                builder.Append('=');
+                builder.Append(Uri.EscapeDataString(kvp.Value));
+            }
+        }
+
+        var request = new HttpRequestMessage(method, builder.ToString());
+        if (body.HasValue && method != HttpMethod.Get)
+        {
+            request.Content = new StringContent(body.Value.GetRawText(), Encoding.UTF8, "application/json");
+        }
+
+        var response = await _http.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<JsonElement>(stream, cancellationToken: cancellationToken);
+    }
+}
+

--- a/plugins/services/BinanceServicePlugin/BinanceServicePlugin.cs
+++ b/plugins/services/BinanceServicePlugin/BinanceServicePlugin.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using TaskHub.Abstractions;
+
+namespace BinanceServicePlugin;
+
+public class BinanceServicePlugin : IServicePlugin, IDisposable
+{
+    private readonly ServiceProvider _provider;
+    private readonly BinanceClient _client;
+
+    public BinanceServicePlugin()
+    {
+        var services = new ServiceCollection();
+        services.AddHttpClient<BinanceClient>();
+        _provider = services.BuildServiceProvider();
+        _client = _provider.GetRequiredService<BinanceClient>();
+    }
+
+    public string Name => "binance";
+
+    public object GetService() => _client;
+
+    public void Dispose()
+    {
+        _provider.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/plugins/services/BinanceServicePlugin/BinanceServicePlugin.csproj
+++ b/plugins/services/BinanceServicePlugin/BinanceServicePlugin.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\..\\..\\src\\TaskHub.Abstractions\\TaskHub.Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/plugins/services/BinanceServicePlugin/ExchangeInfo.cs
+++ b/plugins/services/BinanceServicePlugin/ExchangeInfo.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace BinanceServicePlugin;
+
+public class ExchangeInfo
+{
+    [JsonPropertyName("timezone")]
+    public string? Timezone { get; set; }
+
+    [JsonPropertyName("serverTime")]
+    public long ServerTime { get; set; }
+}
+

--- a/plugins/services/BinanceServicePlugin/ServerTime.cs
+++ b/plugins/services/BinanceServicePlugin/ServerTime.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace BinanceServicePlugin;
+
+public class ServerTime
+{
+    [JsonPropertyName("serverTime")]
+    public long Time { get; set; }
+}
+

--- a/plugins/services/BinanceServicePlugin/TickerPrice.cs
+++ b/plugins/services/BinanceServicePlugin/TickerPrice.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace BinanceServicePlugin;
+
+public class TickerPrice
+{
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; set; }
+
+    [JsonPropertyName("price")]
+    public decimal Price { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- extend Binance client with convert endpoints (get quote, accept quote, order status, trade flow)
- wire convert endpoints into Binance command handler with dedicated commands

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67912ae40832183815c13a988adfe