### PR TITLE
Add typed SQL query support and mapper tests

### DIFF
--- a/TaskHub.sln
+++ b/TaskHub.sln
@@ -121,6 +121,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BinanceServicePlugin", "plu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BinanceHandler", "plugins/handlers/BinanceHandler/BinanceHandler.csproj", "{EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SqlServicePlugin", "plugins/services/SqlServicePlugin/SqlServicePlugin.csproj", "{3957D3BA-4B23-4DE0-8108-0979291E6247}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SqlServicePlugin.Tests", "tests/SqlServicePlugin.Tests/SqlServicePlugin.Tests.csproj", "{28BE32CD-90E8-4BD8-83A1-B27E921BFA90}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -363,6 +367,14 @@ Global
         {EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {EAFD6265-DE4D-4F00-9309-CF0363A8ACD3}.Release|Any CPU.Build.0 = Release|Any CPU
+        {3957D3BA-4B23-4DE0-8108-0979291E6247}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {3957D3BA-4B23-4DE0-8108-0979291E6247}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {3957D3BA-4B23-4DE0-8108-0979291E6247}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {3957D3BA-4B23-4DE0-8108-0979291E6247}.Release|Any CPU.Build.0 = Release|Any CPU
+        {28BE32CD-90E8-4BD8-83A1-B27E921BFA90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {28BE32CD-90E8-4BD8-83A1-B27E921BFA90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {28BE32CD-90E8-4BD8-83A1-B27E921BFA90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {28BE32CD-90E8-4BD8-83A1-B27E921BFA90}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/plugins/services/SqlServicePlugin/Properties/AssemblyInfo.cs
+++ b/plugins/services/SqlServicePlugin/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SqlServicePlugin.Tests")]

--- a/plugins/services/SqlServicePlugin/SqlRowMapper.cs
+++ b/plugins/services/SqlServicePlugin/SqlRowMapper.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data;
+using System.Globalization;
+using System.Reflection;
+
+namespace SqlServicePlugin;
+
+internal static class SqlRowMapper
+{
+    private static readonly ConcurrentDictionary<Type, Dictionary<string, PropertyInfo>> PropertyMaps = new();
+
+    public static T MapToType<T>(IDataRecord record)
+        where T : new()
+    {
+        var instance = new T();
+        var propertyMap = PropertyMaps.GetOrAdd(typeof(T), CreatePropertyMap);
+
+        for (var i = 0; i < record.FieldCount; i++)
+        {
+            if (!propertyMap.TryGetValue(record.GetName(i), out var property))
+            {
+                continue;
+            }
+
+            var rawValue = record.IsDBNull(i) ? null : record.GetValue(i);
+            if (rawValue is null)
+            {
+                if (IsNullable(property.PropertyType))
+                {
+                    property.SetValue(instance, null);
+                }
+
+                continue;
+            }
+
+            var targetType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+
+            try
+            {
+                var convertedValue = ConvertValue(rawValue, targetType);
+                property.SetValue(instance, convertedValue);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to convert column '{record.GetName(i)}' to property '{property.Name}' of type '{property.PropertyType.FullName}'.",
+                    ex);
+            }
+        }
+
+        return instance;
+    }
+
+    private static Dictionary<string, PropertyInfo> CreatePropertyMap(Type type)
+    {
+        var map = new Dictionary<string, PropertyInfo>(StringComparer.OrdinalIgnoreCase);
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        foreach (var property in properties)
+        {
+            if (!property.CanWrite)
+            {
+                continue;
+            }
+
+            map[property.Name] = property;
+        }
+
+        return map;
+    }
+
+    private static bool IsNullable(Type type) => !type.IsValueType || Nullable.GetUnderlyingType(type) is not null;
+
+    private static object ConvertValue(object value, Type targetType)
+    {
+        if (targetType.IsInstanceOfType(value))
+        {
+            return value;
+        }
+
+        if (targetType.IsEnum)
+        {
+            if (value is string stringValue)
+            {
+                return Enum.Parse(targetType, stringValue, ignoreCase: true);
+            }
+
+            var underlying = Enum.GetUnderlyingType(targetType);
+            var converted = Convert.ChangeType(value, underlying, CultureInfo.InvariantCulture);
+            return Enum.ToObject(targetType, converted!);
+        }
+
+        if (targetType == typeof(Guid))
+        {
+            return value switch
+            {
+                Guid guidValue => guidValue,
+                string guidString => Guid.Parse(guidString),
+                _ => Guid.Parse(Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty)
+            };
+        }
+
+        if (targetType == typeof(DateTimeOffset))
+        {
+            return value switch
+            {
+                DateTimeOffset dto => dto,
+                DateTime dt => new DateTimeOffset(dt),
+                string str => DateTimeOffset.Parse(str, CultureInfo.InvariantCulture),
+                _ => new DateTimeOffset(Convert.ToDateTime(value, CultureInfo.InvariantCulture))
+            };
+        }
+
+        if (targetType == typeof(TimeSpan))
+        {
+            return value switch
+            {
+                TimeSpan ts => ts,
+                string str => TimeSpan.Parse(str, CultureInfo.InvariantCulture),
+                _ => TimeSpan.FromTicks(Convert.ToInt64(value, CultureInfo.InvariantCulture))
+            };
+        }
+
+        return Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture)!;
+    }
+}

--- a/plugins/services/SqlServicePlugin/SqlService.cs
+++ b/plugins/services/SqlServicePlugin/SqlService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using TaskHub.Abstractions;
@@ -22,25 +24,11 @@ public class SqlServicePlugin : IServicePlugin
             _connectionString = connectionString;
         }
 
-        public async Task<OperationResult> QueryAsync(string query)
+        public async Task<OperationResult> QueryAsync(string query, CancellationToken cancellationToken = default)
         {
             try
             {
-                await using var connection = new SqlConnection(_connectionString);
-                await connection.OpenAsync();
-                await using var command = new SqlCommand(query, connection);
-                await using var reader = await command.ExecuteReaderAsync();
-                var rows = new List<Dictionary<string, object?>>();
-                while (await reader.ReadAsync())
-                {
-                    var row = new Dictionary<string, object?>(reader.FieldCount, StringComparer.OrdinalIgnoreCase);
-                    for (var i = 0; i < reader.FieldCount; i++)
-                    {
-                        var value = reader.IsDBNull(i) ? null : reader.GetValue(i);
-                        row[reader.GetName(i)] = value;
-                    }
-                    rows.Add(row);
-                }
+                var rows = await QueryInternalAsync(query, static record => ReadRow(record), cancellationToken);
                 var element = JsonSerializer.SerializeToElement(rows);
                 return new OperationResult(element, "success");
             }
@@ -50,11 +38,33 @@ public class SqlServicePlugin : IServicePlugin
             }
         }
 
+        public Task<IReadOnlyList<T>> QueryAsync<T>(string query, CancellationToken cancellationToken = default)
+            where T : new()
+        {
+            return QueryInternalAsync(query, static record => SqlRowMapper.MapToType<T>(record), cancellationToken);
+        }
+
         public Task<OperationResult> InsertAsync(string commandText) => ExecuteNonQueryAsync(commandText);
 
         public Task<OperationResult> UpdateAsync(string commandText) => ExecuteNonQueryAsync(commandText);
 
         public Task<OperationResult> DeleteAsync(string commandText) => ExecuteNonQueryAsync(commandText);
+
+        private async Task<IReadOnlyList<T>> QueryInternalAsync<T>(string query, Func<IDataRecord, T> map, CancellationToken cancellationToken)
+        {
+            await using var connection = new SqlConnection(_connectionString);
+            await connection.OpenAsync(cancellationToken);
+            await using var command = new SqlCommand(query, connection);
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            var results = new List<T>();
+            while (await reader.ReadAsync(cancellationToken))
+            {
+                results.Add(map(reader));
+            }
+
+            return results;
+        }
 
         private async Task<OperationResult> ExecuteNonQueryAsync(string commandText)
         {
@@ -71,6 +81,18 @@ public class SqlServicePlugin : IServicePlugin
             {
                 return new OperationResult(null, $"Failed to execute command: {ex.Message}");
             }
+        }
+
+        private static Dictionary<string, object?> ReadRow(IDataRecord record)
+        {
+            var row = new Dictionary<string, object?>(record.FieldCount, StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < record.FieldCount; i++)
+            {
+                var value = record.IsDBNull(i) ? null : record.GetValue(i);
+                row[record.GetName(i)] = value;
+            }
+
+            return row;
         }
     }
 }

--- a/tests/SqlServicePlugin.Tests/FakeDataRecord.cs
+++ b/tests/SqlServicePlugin.Tests/FakeDataRecord.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Data;
+using System.Globalization;
+
+namespace SqlServicePlugin.Tests;
+
+internal sealed class FakeDataRecord : IDataRecord
+{
+    private readonly string[] _names;
+    private readonly object?[] _values;
+
+    public FakeDataRecord(params (string Name, object? Value)[] values)
+    {
+        _names = new string[values.Length];
+        _values = new object?[values.Length];
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            _names[i] = values[i].Name;
+            _values[i] = values[i].Value;
+        }
+    }
+
+    public int FieldCount => _values.Length;
+
+    public object this[int i] => _values[i]!;
+
+    public object this[string name] => _values[GetOrdinal(name)]!;
+
+    public string GetName(int i) => _names[i];
+
+    public string GetDataTypeName(int i) => GetFieldType(i).Name;
+
+    public Type GetFieldType(int i)
+    {
+        var value = _values[i];
+        return value?.GetType() ?? typeof(DBNull);
+    }
+
+    public object GetValue(int i) => _values[i]!;
+
+    public int GetValues(object[] values)
+    {
+        var length = Math.Min(values.Length, _values.Length);
+        Array.Copy(_values, values, length);
+        return length;
+    }
+
+    public int GetOrdinal(string name)
+    {
+        for (var i = 0; i < _names.Length; i++)
+        {
+            if (string.Equals(_names[i], name, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+
+        throw new IndexOutOfRangeException($"Column '{name}' not found.");
+    }
+
+    public bool GetBoolean(int i) => Convert.ToBoolean(_values[i], CultureInfo.InvariantCulture);
+
+    public byte GetByte(int i) => Convert.ToByte(_values[i], CultureInfo.InvariantCulture);
+
+    public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length) => throw new NotSupportedException();
+
+    public char GetChar(int i) => Convert.ToChar(_values[i], CultureInfo.InvariantCulture);
+
+    public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length) => throw new NotSupportedException();
+
+    public Guid GetGuid(int i) => _values[i] switch
+    {
+        Guid guid => guid,
+        string str => Guid.Parse(str),
+        _ => Guid.Parse(Convert.ToString(_values[i], CultureInfo.InvariantCulture) ?? string.Empty)
+    };
+
+    public short GetInt16(int i) => Convert.ToInt16(_values[i], CultureInfo.InvariantCulture);
+
+    public int GetInt32(int i) => Convert.ToInt32(_values[i], CultureInfo.InvariantCulture);
+
+    public long GetInt64(int i) => Convert.ToInt64(_values[i], CultureInfo.InvariantCulture);
+
+    public float GetFloat(int i) => Convert.ToSingle(_values[i], CultureInfo.InvariantCulture);
+
+    public double GetDouble(int i) => Convert.ToDouble(_values[i], CultureInfo.InvariantCulture);
+
+    public string GetString(int i) => Convert.ToString(_values[i], CultureInfo.InvariantCulture) ?? string.Empty;
+
+    public decimal GetDecimal(int i) => Convert.ToDecimal(_values[i], CultureInfo.InvariantCulture);
+
+    public DateTime GetDateTime(int i) => Convert.ToDateTime(_values[i], CultureInfo.InvariantCulture);
+
+    public IDataReader GetData(int i) => throw new NotSupportedException();
+
+    public bool IsDBNull(int i) => _values[i] is null || _values[i] is DBNull;
+}

--- a/tests/SqlServicePlugin.Tests/SqlRowMapperTests.cs
+++ b/tests/SqlServicePlugin.Tests/SqlRowMapperTests.cs
@@ -1,0 +1,98 @@
+using System;
+using Xunit;
+
+namespace SqlServicePlugin.Tests;
+
+public class SqlRowMapperTests
+{
+    private enum Status
+    {
+        Unknown = 0,
+        Active = 1
+    }
+
+    private sealed class SampleRecord
+    {
+        public int Id { get; set; }
+
+        public string? Name { get; set; }
+
+        public DateTime Created { get; set; }
+    }
+
+    [Fact]
+    public void MapToType_PopulatesWritableProperties()
+    {
+        var record = new FakeDataRecord(
+            ("Id", 42),
+            ("Name", "TaskHub"),
+            ("Created", new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+        );
+
+        var result = SqlRowMapper.MapToType<SampleRecord>(record);
+
+        Assert.Equal(42, result.Id);
+        Assert.Equal("TaskHub", result.Name);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), result.Created);
+    }
+
+    private sealed class NullableRecord
+    {
+        public int? Count { get; set; }
+
+        public string? Missing { get; set; }
+    }
+
+    [Fact]
+    public void MapToType_HandlesNullableProperties()
+    {
+        var record = new FakeDataRecord(
+            ("Count", DBNull.Value),
+            ("Ignored", "value")
+        );
+
+        var result = SqlRowMapper.MapToType<NullableRecord>(record);
+
+        Assert.Null(result.Count);
+        Assert.Null(result.Missing);
+    }
+
+    private sealed class ConversionRecord
+    {
+        public Status Status { get; set; }
+
+        public Guid Identifier { get; set; }
+
+        public TimeSpan Duration { get; set; }
+    }
+
+    [Fact]
+    public void MapToType_PerformsCommonConversions()
+    {
+        var identifier = Guid.NewGuid();
+        var record = new FakeDataRecord(
+            ("Status", "Active"),
+            ("Identifier", identifier.ToString()),
+            ("Duration", "00:00:05")
+        );
+
+        var result = SqlRowMapper.MapToType<ConversionRecord>(record);
+
+        Assert.Equal(Status.Active, result.Status);
+        Assert.Equal(identifier, result.Identifier);
+        Assert.Equal(TimeSpan.FromSeconds(5), result.Duration);
+    }
+
+    private sealed class NonNullableRecord
+    {
+        public int Count { get; set; }
+    }
+
+    [Fact]
+    public void MapToType_ThrowsWhenConversionFails()
+    {
+        var record = new FakeDataRecord(("Count", "invalid"));
+
+        Assert.Throws<InvalidOperationException>(() => SqlRowMapper.MapToType<NonNullableRecord>(record));
+    }
+}

--- a/tests/SqlServicePlugin.Tests/SqlServicePlugin.Tests.csproj
+++ b/tests/SqlServicePlugin.Tests/SqlServicePlugin.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\plugins\services\SqlServicePlugin\SqlServicePlugin.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- extend the SQL service plugin to expose cancellation-aware query execution and a generic method for strongly typed materialization
- add a reusable row mapper that converts IDataRecord instances into typed objects with common conversions
- introduce unit tests for the mapper and wire the SQL service plugin and tests into the solution

## Testing
- `dotnet test TaskHub.sln` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bafe54d08321a2ed8ca19ac7f298